### PR TITLE
CHECK_EQUAL no longer crashes if string pointers are NULL.

### DIFF
--- a/src/Checks.cpp
+++ b/src/Checks.cpp
@@ -10,10 +10,10 @@ void CheckStringsEqual(TestResults& results, char const* expected, char const* a
 {
 	using namespace std;
 
-    if (strcmp(expected, actual))
+    if ((expected && actual) ? strcmp(expected, actual) : (expected || actual))
     {
         UnitTest::MemoryOutStream stream;
-        stream << "Expected " << expected << " but was " << actual;
+        stream << "Expected " << (expected ? expected : "<NULLPTR>") << " but was " << (actual ? actual : "<NULLPTR>");
 
         results.OnTestFailure(details, stream.GetText());
     }

--- a/src/tests/TestChecks.cpp
+++ b/src/tests/TestChecks.cpp
@@ -72,6 +72,33 @@ TEST(CheckEqualsWithStringsWorksOnContentsWithALiteral)
     CHECK_EQUAL(0, results.GetFailureCount());
 }
 
+TEST(CheckEqualsWithStringsWorksOnNullExpected)
+{
+    char const* const expected = "hi";
+    char const* const actual = NULL;
+    TestResults results;
+    CheckEqual(results, expected, actual, TestDetails("", "", "", 0));
+    CHECK_EQUAL (1, results.GetFailureCount());
+}
+
+TEST(CheckEqualsWithStringsWorksOnNullActual)
+{
+    char const* const expected = NULL;
+    char const* const actual = "hi";
+    TestResults results;
+    CheckEqual(results, expected, actual, TestDetails("", "", "", 0));
+    CHECK_EQUAL (1, results.GetFailureCount());
+}
+
+TEST(CheckEqualsWithStringsWorksOnNullExpectedAndActual)
+{
+    char const* const expected = NULL;
+    char const* const actual = NULL;
+    TestResults results;
+    CheckEqual(results, expected, actual, TestDetails("", "", "", 0));
+    CHECK_EQUAL (0, results.GetFailureCount());
+}
+
 TEST(CheckEqualFailureIncludesCheckExpectedAndActual)
 {
     RecordingReporter reporter;


### PR DESCRIPTION
This pull request closes #8. I took the test cases from Tom Barta's (tbarta) comment here:
http://sourceforge.net/tracker/?func=detail&aid=1844387&group_id=158151&atid=806684

However, I chose a slightly different method to modify the code to avoid multiple returns.
