### PR TITLE
Changed all parameters to TestReporterStdout::ReportSummary to be const.

### DIFF
--- a/src/TestReporterStdout.cpp
+++ b/src/TestReporterStdout.cpp
@@ -31,7 +31,7 @@ void TestReporterStdout::ReportTestFinish(TestDetails const& /*test*/, float)
 }
 
 void TestReporterStdout::ReportSummary(int const totalTestCount, int const failedTestCount,
-                                       int const failureCount, float secondsElapsed)
+                                       int const failureCount, float const secondsElapsed)
 {
 	using namespace std;
 

--- a/src/TestReporterStdout.h
+++ b/src/TestReporterStdout.h
@@ -11,7 +11,7 @@ private:
     virtual void ReportTestStart(TestDetails const& test);
     virtual void ReportFailure(TestDetails const& test, char const* failure);
     virtual void ReportTestFinish(TestDetails const& test, float secondsElapsed);
-    virtual void ReportSummary(int totalTestCount, int failedTestCount, int failureCount, float secondsElapsed);
+    virtual void ReportSummary(int const totalTestCount, int const failedTestCount, int const failureCount, float const secondsElapsed);
 };
 
 }


### PR DESCRIPTION
This best preserved the intent of the original definition while supporting a non-conformant compiler that could not handle the mismatch. This closes #15.
