### PR TITLE
Changed sprintf to snprintf in MemoryOutStream::FormatToStream.

### DIFF
--- a/src/MemoryOutStream.cpp
+++ b/src/MemoryOutStream.cpp
@@ -32,8 +32,9 @@ void FormatToStream(MemoryOutStream& stream, char const* format, ValueType const
 {
 	using namespace std;
 
-    char txt[32];
-    sprintf(txt, format, value);
+    const size_t BUFFER_SIZE=32;
+    char txt[BUFFER_SIZE];
+    snprintf(txt, BUFFER_SIZE, format, value);
     stream << txt;
 }
 
@@ -127,7 +128,7 @@ MemoryOutStream& MemoryOutStream::operator <<(unsigned long long const n)
 
 MemoryOutStream& MemoryOutStream::operator <<(float const f)
 {
-    FormatToStream(*this, "%ff", f);
+    FormatToStream(*this, "%0.6f", f);
     return *this;    
 }
 
@@ -145,7 +146,7 @@ MemoryOutStream& MemoryOutStream::operator <<(unsigned int const s)
 
 MemoryOutStream& MemoryOutStream::operator <<(double const d)
 {
-	FormatToStream(*this, "%f", d);
+	FormatToStream(*this, "%0.6f", d);
 	return *this;
 }
 

--- a/src/tests/TestMemoryOutStream.cpp
+++ b/src/tests/TestMemoryOutStream.cpp
@@ -4,6 +4,7 @@
 #include <cstring>
 #include <climits>
 #include <cstdlib>
+#include <cfloat>
 
 using namespace UnitTest;
 using namespace std;
@@ -152,15 +153,15 @@ TEST(WritingStringLongerThanCapacityFitsInNewBuffer)
 TEST(WritingIntLongerThanCapacityFitsInNewBuffer)
 {
     MemoryOutStream stream(8);
-    stream << "aaaa" << 123456;;
+    stream << "aaaa" << 123456;
     CHECK_EQUAL("aaaa123456", stream.GetText());
 }
 
 TEST(WritingFloatLongerThanCapacityFitsInNewBuffer)
 {
     MemoryOutStream stream(8);
-    stream << "aaaa" << 123456.0f;;
-    CHECK_EQUAL("aaaa123456.000000f", stream.GetText());
+    stream << "aaaa" << 123456.0f;
+    CHECK_EQUAL("aaaa123456.000000", stream.GetText());
 }
 
 TEST(WritingSizeTLongerThanCapacityFitsInNewBuffer)
@@ -168,6 +169,13 @@ TEST(WritingSizeTLongerThanCapacityFitsInNewBuffer)
     MemoryOutStream stream(8);
     stream << "aaaa" << size_t(32145);
     CHECK_EQUAL("aaaa32145", stream.GetText());
+}
+
+TEST(VerifyLargeDoubleCanBeStreamedWithoutCrashing)
+{
+    MemoryOutStream stream(8);
+    stream << DBL_MAX;
+    CHECK(true);
 }
 
 #endif


### PR DESCRIPTION
Removed trailing 'f' from floats and formatted all floats and doubles to '%0.6f'. This will address issue #18.
