### PR TITLE
Integrating test failures into QTCreator IDE build errors

### DIFF
--- a/UnitTest++/TestReporterStdout.cpp
+++ b/UnitTest++/TestReporterStdout.cpp
@@ -13,13 +13,13 @@ namespace UnitTest {
 void TestReporterStdout::ReportFailure(TestDetails const& details, char const* failure)
 {
 #if defined(__APPLE__) || defined(__GNUG__)
-    char const* const errorFormat = "%s:%d: error: Failure in %s: %s\n";
+    char const* const errorFormat = "%s:%d:%d: error: Failure in %s: %s\n";
 #else
     char const* const errorFormat = "%s(%d): error: Failure in %s: %s\n";
 #endif
 
 	using namespace std;
-    printf(errorFormat, details.filename, details.lineNumber, details.testName, failure);
+    fprintf(stderr, errorFormat, details.filename, details.lineNumber, 1, details.testName, failure);
 }
 
 void TestReporterStdout::ReportTestStart(TestDetails const& /*test*/)


### PR DESCRIPTION
Some small changes to integrate the test run failures into QTCreator IDE build errors, there by showing the failures as issues in the Issue panel of the IDE.
more details:  http://www.mail-archive.com/unittest-cpp-devel@lists.sourceforge.net/msg00367.html
