### PR TITLE
Fix crash bug in msvc

### DIFF
--- a/UnitTest++/TestReporterStdout.cpp
+++ b/UnitTest++/TestReporterStdout.cpp
@@ -12,14 +12,14 @@ namespace UnitTest {
 
 void TestReporterStdout::ReportFailure(TestDetails const& details, char const* failure)
 {
+    using namespace std;
 #if defined(__APPLE__) || defined(__GNUG__)
     char const* const errorFormat = "%s:%d:%d: error: Failure in %s: %s\n";
+    fprintf(stderr, errorFormat, details.filename, details.lineNumber, 1, details.testName, failure);
 #else
     char const* const errorFormat = "%s(%d): error: Failure in %s: %s\n";
+    fprintf(stderr, errorFormat, details.filename, details.lineNumber, details.testName, failure);
 #endif
-
-	using namespace std;
-    fprintf(stderr, errorFormat, details.filename, details.lineNumber, 1, details.testName, failure);
 }
 
 void TestReporterStdout::ReportTestStart(TestDetails const& /*test*/)


### PR DESCRIPTION
fprintf had incorrect number of arguments.
