### PR TITLE
Adding conditional automake directives to allow Win32 compilation on win...

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,5 @@
 ACLOCAL_AMFLAGS = -I m4
 EXTRA_DIST = docs
-SUBDIRS = UnitTest++
+
+include UnitTest++/Makefile.am
+include tests/Makefile.am

--- a/UnitTest++/Makefile.am
+++ b/UnitTest++/Makefile.am
@@ -10,7 +10,6 @@ UnitTest___libUnitTest___la_SOURCES += UnitTest++/Win32/TimeHelpers.cpp
 else 
 nobase_pkginclude_HEADERS += UnitTest++/Posix/SignalTranslator.h UnitTest++/Posix/TimeHelpers.h
 UnitTest___libUnitTest___la_SOURCES += UnitTest++/Posix/SignalTranslator.cpp UnitTest++/Posix/TimeHelpers.cpp
-UnitTest___libUnitTest___la_CPPFLAGS += -DUNITTEST_POSIX
 endif
 
 UnitTest___libUnitTest___la_LDFLAGS = -version-number @LIBUNITTEST_SO_VERSION@

--- a/UnitTest++/Makefile.am
+++ b/UnitTest++/Makefile.am
@@ -2,7 +2,6 @@ lib_LTLIBRARIES = UnitTest++/libUnitTest++.la
 pkgincludedir = $(includedir)/UnitTest++/
 nobase_pkginclude_HEADERS = UnitTest++/UnitTest++.h UnitTest++/UnitTestPP.h UnitTest++/Config.h UnitTest++/HelperMacros.h UnitTest++/Test.h UnitTest++/TestDetails.h UnitTest++/TestList.h UnitTest++/TestSuite.h UnitTest++/TestResults.h UnitTest++/TestMacros.h UnitTest++/CheckMacros.h UnitTest++/TestRunner.h UnitTest++/TimeConstraint.h UnitTest++/ExecuteTest.h UnitTest++/AssertException.h UnitTest++/MemoryOutStream.h UnitTest++/CurrentTest.h  UnitTest++/Checks.h UnitTest++/TimeHelpers.h  UnitTest++/ExceptionMacros.h UnitTest++/ReportAssert.h UnitTest++/ReportAssertImpl.h UnitTest++/TestReporter.h UnitTest++/TestReporterStdout.h UnitTest++/CompositeTestReporter.h UnitTest++/DeferredTestReporter.h UnitTest++/DeferredTestResult.h
 UnitTest___libUnitTest___la_SOURCES = UnitTest++/AssertException.cpp UnitTest++/Test.cpp UnitTest++/Checks.cpp UnitTest++/TestRunner.cpp UnitTest++/TestResults.cpp UnitTest++/TestReporter.cpp UnitTest++/TestReporterStdout.cpp UnitTest++/ReportAssert.cpp UnitTest++/TestList.cpp UnitTest++/TimeConstraint.cpp UnitTest++/TestDetails.cpp UnitTest++/MemoryOutStream.cpp UnitTest++/DeferredTestReporter.cpp UnitTest++/DeferredTestResult.cpp UnitTest++/XmlTestReporter.cpp UnitTest++/CurrentTest.cpp  UnitTest++/CompositeTestReporter.cpp
-UnitTest___libUnitTest___la_CPPFLAGS = 
 
 if WINDOWS 
 nobase_pkginclude_HEADERS += UnitTest++/Win32/TimeHelpers.h

--- a/UnitTest++/Makefile.am
+++ b/UnitTest++/Makefile.am
@@ -1,9 +1,18 @@
-lib_LTLIBRARIES = libUnitTest++.la
-pkgincludedir = $(includedir)/UnitTest++
-nobase_pkginclude_HEADERS = UnitTest++.h UnitTestPP.h Config.h HelperMacros.h Test.h TestDetails.h TestList.h TestSuite.h TestResults.h TestMacros.h CheckMacros.h TestRunner.h TimeConstraint.h ExecuteTest.h AssertException.h MemoryOutStream.h CurrentTest.h Posix/SignalTranslator.h Checks.h TimeHelpers.h Posix/TimeHelpers.h ExceptionMacros.h ReportAssert.h ReportAssertImpl.h TestReporter.h TestReporterStdout.h CompositeTestReporter.h DeferredTestReporter.h DeferredTestResult.h
-libUnitTest___la_SOURCES = AssertException.cpp Test.cpp Checks.cpp TestRunner.cpp TestResults.cpp TestReporter.cpp TestReporterStdout.cpp ReportAssert.cpp TestList.cpp TimeConstraint.cpp TestDetails.cpp MemoryOutStream.cpp DeferredTestReporter.cpp DeferredTestResult.cpp XmlTestReporter.cpp CurrentTest.cpp Posix/SignalTranslator.cpp Posix/TimeHelpers.cpp CompositeTestReporter.cpp
-libUnitTest___la_LDFLAGS = -version-number @LIBUNITTEST_SO_VERSION@
-check_PROGRAMS = TestUnitTest++
-TestUnitTest___SOURCES = $(top_srcdir)/tests/Main.cpp $(top_srcdir)/tests/TestAssertHandler.cpp $(top_srcdir)/tests/TestCheckMacros.cpp $(top_srcdir)/tests/TestChecks.cpp $(top_srcdir)/tests/TestCompositeTestReporter.cpp $(top_srcdir)/tests/TestCurrentTest.cpp $(top_srcdir)/tests/TestDeferredTestReporter.cpp $(top_srcdir)/tests/TestExceptions.cpp $(top_srcdir)/tests/TestMemoryOutStream.cpp $(top_srcdir)/tests/TestTest.cpp $(top_srcdir)/tests/TestTestList.cpp $(top_srcdir)/tests/TestTestMacros.cpp $(top_srcdir)/tests/TestTestResults.cpp $(top_srcdir)/tests/TestTestRunner.cpp $(top_srcdir)/tests/TestTestSuite.cpp $(top_srcdir)/tests/TestTimeConstraint.cpp $(top_srcdir)/tests/TestTimeConstraintMacro.cpp $(top_srcdir)/tests/TestUnitTestPP.cpp $(top_srcdir)/tests/TestXmlTestReporter.cpp
-TestUnitTest___LDADD = libUnitTest++.la
-TESTS = TestUnitTest++
+lib_LTLIBRARIES = UnitTest++/libUnitTest++.la
+pkgincludedir = $(includedir)/UnitTest++/
+nobase_pkginclude_HEADERS = UnitTest++/UnitTest++.h UnitTest++/UnitTestPP.h UnitTest++/Config.h UnitTest++/HelperMacros.h UnitTest++/Test.h UnitTest++/TestDetails.h UnitTest++/TestList.h UnitTest++/TestSuite.h UnitTest++/TestResults.h UnitTest++/TestMacros.h UnitTest++/CheckMacros.h UnitTest++/TestRunner.h UnitTest++/TimeConstraint.h UnitTest++/ExecuteTest.h UnitTest++/AssertException.h UnitTest++/MemoryOutStream.h UnitTest++/CurrentTest.h  UnitTest++/Checks.h UnitTest++/TimeHelpers.h  UnitTest++/ExceptionMacros.h UnitTest++/ReportAssert.h UnitTest++/ReportAssertImpl.h UnitTest++/TestReporter.h UnitTest++/TestReporterStdout.h UnitTest++/CompositeTestReporter.h UnitTest++/DeferredTestReporter.h UnitTest++/DeferredTestResult.h
+UnitTest___libUnitTest___la_SOURCES = UnitTest++/AssertException.cpp UnitTest++/Test.cpp UnitTest++/Checks.cpp UnitTest++/TestRunner.cpp UnitTest++/TestResults.cpp UnitTest++/TestReporter.cpp UnitTest++/TestReporterStdout.cpp UnitTest++/ReportAssert.cpp UnitTest++/TestList.cpp UnitTest++/TimeConstraint.cpp UnitTest++/TestDetails.cpp UnitTest++/MemoryOutStream.cpp UnitTest++/DeferredTestReporter.cpp UnitTest++/DeferredTestResult.cpp UnitTest++/XmlTestReporter.cpp UnitTest++/CurrentTest.cpp  UnitTest++/CompositeTestReporter.cpp
+UnitTest___libUnitTest___la_CPPFLAGS = 
+
+if WINDOWS 
+nobase_pkginclude_HEADERS += UnitTest++/Win32/TimeHelpers.h
+UnitTest___libUnitTest___la_SOURCES += UnitTest++/Win32/TimeHelpers.cpp
+else 
+nobase_pkginclude_HEADERS += UnitTest++/Posix/SignalTranslator.h UnitTest++/Posix/TimeHelpers.h
+UnitTest___libUnitTest___la_SOURCES += UnitTest++/Posix/SignalTranslator.cpp UnitTest++/Posix/TimeHelpers.cpp
+UnitTest___libUnitTest___la_CPPFLAGS += -DUNITTEST_POSIX
+endif
+
+UnitTest___libUnitTest___la_LDFLAGS = -version-number @LIBUNITTEST_SO_VERSION@
+
+

--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,8 @@ AC_CONFIG_SRCDIR([UnitTest++/TestDetails.cpp])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS([config.h])
 
-AM_INIT_AUTOMAKE([foreign])
+AM_INIT_AUTOMAKE([foreign subdir-objects])
+AM_CONDITIONAL([WINDOWS], [test "$OS" == "Windows_NT"])
 LT_INIT()
 
 AC_SUBST([LIBUNITTEST_SO_VERSION], [1:4:1])
@@ -29,6 +30,5 @@ AC_TYPE_SIZE_T
 # Checks for library functions.
 AC_CHECK_FUNCS([gettimeofday strstr])
 
-AC_CONFIG_FILES([Makefile
-		 UnitTest++/Makefile])
+AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,8 @@ AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS([config.h])
 
 AM_INIT_AUTOMAKE([foreign subdir-objects])
-AM_CONDITIONAL([WINDOWS], [test "$OS" == "Windows_NT"])
+AM_CONDITIONAL([WINDOWS],
+	  [test "${host#*mingw}" != "${host}" -o "${host#*msvc}" != "${host}"])
 LT_INIT()
 
 AC_SUBST([LIBUNITTEST_SO_VERSION], [1:4:1])

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,0 +1,4 @@
+check_PROGRAMS = UnitTest++/TestUnitTest++
+UnitTest___TestUnitTest___SOURCES = tests/Main.cpp tests/TestAssertHandler.cpp tests/TestCheckMacros.cpp tests/TestChecks.cpp tests/TestCompositeTestReporter.cpp tests/TestCurrentTest.cpp tests/TestDeferredTestReporter.cpp tests/TestExceptions.cpp tests/TestMemoryOutStream.cpp tests/TestTest.cpp tests/TestTestList.cpp tests/TestTestMacros.cpp tests/TestTestResults.cpp tests/TestTestRunner.cpp tests/TestTestSuite.cpp tests/TestTimeConstraint.cpp tests/TestTimeConstraintMacro.cpp tests/TestUnitTestPP.cpp tests/TestXmlTestReporter.cpp
+UnitTest___TestUnitTest___LDADD = UnitTest++/libUnitTest++.la
+TESTS = UnitTest++/TestUnitTest++


### PR DESCRIPTION
Hello there. 

I know I am probably in the minority, and you provide CMake build files for unittest-cpp.

However, I am using autoconf and automake in a cygwin environment with the mingw cross-compilers to produce Windows builds for a personal project. 

I decided to add a subrepository to my project so that I may easily keep up with new features like the REQUIRE macros. However, the provided autotools script does not detect Windows hosts and attempts to compile with POSIX signal handlers.

I added some simple detection in confugure.ac :
```
AM_CONDITIONAL([WINDOWS], [test "$OS" == "Windows_NT"])
```
Along with conditional statements in Makefile.am, as you can see in the diffs.

However, the tests in the test/ directory were giving me warnings because my cygwin installation uses slightly newer autotools,  urging me to use the `subdir-objects` feature.

I have read that [Recursive Make [is] Considered Harmful](http://aegis.sourceforge.net/auug97.pdf), so I also took the liberty to flatten out the Makefile scripts into a single top-level script that is sourced from each subdirectory's Makefile.am.

This caused the build warnings to go away on cygwin, and provides the same behavior as the previous scripts. I made sure to test `make install` behavior before finalizing this changeset, so that package maintaners (if there are any using autotools) will not be affected.

Please let me know what you think. This is a work in progress, and I am still learning.