### PR TITLE
Continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: cpp
+
+# Build with gcc and clang.
+compiler:
+  - gcc
+  - clang
+
+# Build both debug and release configurations, through use of an environment variable in the build matrix.
+env:
+  - CONFIGURATION=Debug
+  - CONFIGURATION=Release
+
+# Run cmake to generate makefiles in 'builds' directory.
+# No need to create it because it's part of the repo.
+# Pass along configuration type to cmake
+before_script:
+  - cd builds && cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=$CONFIGURATION ../ && cd ..
+
+# Run make in the directory containing generated makefiles.
+script:
+  - make -C builds

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,14 @@
+os:
+  - Windows Server 2012 R2
+
+install:
+  # Generate solution files using cmake, in 'builds' directory.
+  # No need to create it because it's part of the repo.
+  - cd builds && cmake -G "Visual Studio 12" ../ && cd ..
+
+configuration:
+  - Debug
+  - Release
+
+build:
+  project: builds/UnitTest++.sln


### PR DESCRIPTION
I've added configuration files for AppVeyor and Travis CI, building on Windows Server 2012 and Linux, using Cmake, VS2013, GCC and Clang, in Debug and Release configurations. Should be enough to cover us fairly well I reckon!

See it working here:
https://travis-ci.org/hymerman/unittest-cpp
https://ci.appveyor.com/project/hymerman/unittest-cpp

You'll need to register with both services (just log in with GitHub), and add unittest-cpp as a project to be built (easy in both services - they present you with a list of your projects). Once you do that and accept this pull request, it'll all be working.

This closes #68.