### PR TITLE
Add custom message to check macros

### DIFF
--- a/UnitTest++/CheckMacroImplementations.h
+++ b/UnitTest++/CheckMacroImplementations.h
@@ -1,0 +1,155 @@
+#ifndef UNITTEST_CHECKMACROIMPLEMENTATIONS_H
+#define UNITTEST_CHECKMACROIMPLEMENTATIONS_H
+
+#include "HelperMacros.h"
+#include "ExceptionMacros.h"
+#include "Checks.h"
+#include "MemoryOutStream.h"
+#include "TestDetails.h"
+#include "CurrentTest.h"
+
+#define UNITTEST_CHECK_WITH_DESCRIPTION(condition, description) \
+    if (!condition) \
+    { \
+        UnitTest::MemoryOutStream stream; \
+        stream << description; \
+        UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), stream.GetText()); \
+    }
+
+#define UNITTEST_CHECK(value, test_action) \
+    UNITTEST_MULTILINE_MACRO_BEGIN \
+    UT_TRY \
+        ({ \
+            test_action; \
+        }) \
+        UT_CATCH (std::exception, e, \
+        { \
+            UnitTest::MemoryOutStream message; \
+            message << "Unhandled exception (" << e.what() << ") in CHECK(" #value ")"; \
+            UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
+                message.GetText()); \
+        }) \
+        UT_CATCH_ALL \
+        ({ \
+            UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
+                "Unhandled exception in CHECK(" #value ")"); \
+        }) \
+    UNITTEST_MULTILINE_MACRO_END
+
+#define UNITTEST_CHECK_EQUAL(expected, actual, test_action) \
+    UNITTEST_MULTILINE_MACRO_BEGIN \
+        UT_TRY \
+        ({ \
+            test_action; \
+        }) \
+        UT_CATCH (std::exception, e, \
+        { \
+            UnitTest::MemoryOutStream message; \
+            message << "Unhandled exception (" << e.what() << ") in CHECK_EQUAL(" #expected ", " #actual ")"; \
+            UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
+                message.GetText()); \
+        }) \
+        UT_CATCH_ALL \
+        ({ \
+            UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
+                    "Unhandled exception in CHECK_EQUAL(" #expected ", " #actual ")"); \
+        }) \
+    UNITTEST_MULTILINE_MACRO_END
+
+#define UNITTEST_CHECK_CLOSE(expected, actual, tolerance, test_action)      \
+    UNITTEST_MULTILINE_MACRO_BEGIN \
+        UT_TRY \
+        ({ \
+            test_action; \
+        }) \
+        UT_CATCH (std::exception, e, \
+        { \
+            UnitTest::MemoryOutStream message; \
+            message << "Unhandled exception (" << e.what() << ") in CHECK_CLOSE(" #expected ", " #actual ")"; \
+            UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
+                message.GetText()); \
+        }) \
+        UT_CATCH_ALL \
+        ({ \
+            UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
+                    "Unhandled exception in CHECK_CLOSE(" #expected ", " #actual ")"); \
+        }) \
+    UNITTEST_MULTILINE_MACRO_END
+
+#define UNITTEST_CHECK_ARRAY_EQUAL(expected, actual, count, test_action)    \
+    UNITTEST_MULTILINE_MACRO_BEGIN \
+        UT_TRY \
+        ({ \
+            test_action; \
+        }) \
+        UT_CATCH (std::exception, e, \
+        { \
+            UnitTest::MemoryOutStream message; \
+            message << "Unhandled exception (" << e.what() << ") in CHECK_ARRAY_EQUAL(" #expected ", " #actual ")"; \
+            UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
+                message.GetText()); \
+        }) \
+        UT_CATCH_ALL \
+        ({ \
+            UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
+                    "Unhandled exception in CHECK_ARRAY_EQUAL(" #expected ", " #actual ")"); \
+        }) \
+    UNITTEST_MULTILINE_MACRO_END
+
+#define UNITTEST_CHECK_ARRAY_CLOSE(expected, actual, count, tolerance, test_action) \
+    UNITTEST_MULTILINE_MACRO_BEGIN \
+        UT_TRY \
+        ({ \
+            test_action; \
+        }) \
+        UT_CATCH (std::exception, e, \
+        { \
+            UnitTest::MemoryOutStream message; \
+            message << "Unhandled exception (" << e.what() << ") in CHECK_ARRAY_CLOSE(" #expected ", " #actual ")"; \
+            UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
+                message.GetText()); \
+        }) \
+        UT_CATCH_ALL \
+        ({ \
+            UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
+                    "Unhandled exception in CHECK_ARRAY_CLOSE(" #expected ", " #actual ")"); \
+        }) \
+    UNITTEST_MULTILINE_MACRO_END
+
+#define UNITTEST_CHECK_ARRAY2D_CLOSE(expected, actual, rows, columns, tolerance, test_action) \
+    UNITTEST_MULTILINE_MACRO_BEGIN \
+        UT_TRY \
+        ({ \
+            test_action; \
+        }) \
+        UT_CATCH (std::exception, e, \
+        { \
+            UnitTest::MemoryOutStream message; \
+            message << "Unhandled exception (" << e.what() << ") in CHECK_ARRAY2D_CLOSE(" #expected ", " #actual ")"; \
+            UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
+                message.GetText()); \
+        }) \
+        UT_CATCH_ALL \
+        ({ \
+            UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
+                    "Unhandled exception in CHECK_ARRAY2D_CLOSE(" #expected ", " #actual ")"); \
+        }) \
+    UNITTEST_MULTILINE_MACRO_END
+
+#ifndef UNITTEST_NO_EXCEPTIONS
+
+#define UNITTEST_CHECK_THROW(expression, ExpectedExceptionType, failure_action)        \
+    UNITTEST_MULTILINE_MACRO_BEGIN \
+        bool caught_ = false; \
+        try { expression; } \
+        catch (ExpectedExceptionType const&) { caught_ = true; } \
+        catch (...) {} \
+        if (!caught_) \
+        { \
+            failure_action; \
+        } \
+    UNITTEST_MULTILINE_MACRO_END
+
+#endif
+
+#endif

--- a/UnitTest++/CheckMacros.h
+++ b/UnitTest++/CheckMacros.h
@@ -164,6 +164,10 @@
                                UnitTest::CheckArrayClose(*UnitTest::CurrentTest::Results(), expected, actual, count, tolerance, \
                                                          UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__)))
 
+#define CHECK_ARRAY_CLOSE_DESCRIBED(expected, actual, count, tolerance, description) \
+    UNITTEST_CHECK_ARRAY_CLOSE(expected, actual, count, tolerance, \
+                               UNITTEST_CHECK_WITH_DESCRIPTION(UnitTest::ArrayAreClose(expected, actual, count, tolerance), description))
+
 #define UNITTEST_CHECK_ARRAY_CLOSE(expected, actual, count, tolerance, test_action) \
     UNITTEST_MULTILINE_MACRO_BEGIN \
         UT_TRY \

--- a/UnitTest++/CheckMacros.h
+++ b/UnitTest++/CheckMacros.h
@@ -2,13 +2,12 @@
 #define UNITTEST_CHECKMACROS_H
 
 #include "HelperMacros.h"
-#include "ExceptionMacros.h"
 #include "Checks.h"
 #include "AssertException.h"
-#include "MemoryOutStream.h"
 #include "TestDetails.h"
 #include "CurrentTest.h"
 #include "ReportAssertImpl.h"
+#include "CheckMacroImplementations.h"
 
 #ifdef CHECK
     #error UnitTest++ redefines CHECK
@@ -34,14 +33,6 @@
     #error UnitTest++ redefines CHECK_ARRAY2D_CLOSE
 #endif
 
-#define UNITTEST_CHECK_WITH_DESCRIPTION(condition, description) \
-    if (!condition) \
-    { \
-        UnitTest::MemoryOutStream stream; \
-        stream << description; \
-        UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), stream.GetText()); \
-    }
-
 #define CHECK(value) \
     UNITTEST_CHECK(value, \
                    if (!UnitTest::Check(value)) \
@@ -52,26 +43,6 @@
 #define CHECK_DESCRIBED(value, description) \
     UNITTEST_CHECK(value, UNITTEST_CHECK_WITH_DESCRIPTION(UnitTest::Check(value), description))
 
-#define UNITTEST_CHECK(value, test_action) \
-    UNITTEST_MULTILINE_MACRO_BEGIN \
-    UT_TRY \
-        ({ \
-            test_action; \
-        }) \
-        UT_CATCH (std::exception, e, \
-        { \
-            UnitTest::MemoryOutStream message; \
-            message << "Unhandled exception (" << e.what() << ") in CHECK(" #value ")"; \
-            UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
-                message.GetText()); \
-        }) \
-        UT_CATCH_ALL \
-        ({ \
-            UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
-                "Unhandled exception in CHECK(" #value ")"); \
-        }) \
-    UNITTEST_MULTILINE_MACRO_END
-
 #define CHECK_EQUAL(expected, actual) \
     UNITTEST_CHECK_EQUAL(expected, actual, \
                          UnitTest::CheckEqual(*UnitTest::CurrentTest::Results(), expected, actual, \
@@ -80,26 +51,6 @@
 #define CHECK_EQUAL_DESCRIBED(expected, actual, description) \
     UNITTEST_CHECK_EQUAL(expected, actual, \
                          UNITTEST_CHECK_WITH_DESCRIPTION(UnitTest::AreEqual(expected, actual), description))
-
-#define UNITTEST_CHECK_EQUAL(expected, actual, test_action) \
-    UNITTEST_MULTILINE_MACRO_BEGIN \
-        UT_TRY \
-        ({ \
-            test_action; \
-        }) \
-        UT_CATCH (std::exception, e, \
-        { \
-            UnitTest::MemoryOutStream message; \
-            message << "Unhandled exception (" << e.what() << ") in CHECK_EQUAL(" #expected ", " #actual ")"; \
-            UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
-                message.GetText()); \
-        }) \
-        UT_CATCH_ALL \
-        ({ \
-            UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
-                    "Unhandled exception in CHECK_EQUAL(" #expected ", " #actual ")"); \
-        }) \
-    UNITTEST_MULTILINE_MACRO_END
 
 #define CHECK_CLOSE(expected, actual, tolerance) \
     UNITTEST_CHECK_CLOSE(expected, actual, tolerance, \
@@ -110,26 +61,6 @@
     UNITTEST_CHECK_CLOSE(expected, actual, tolerance, \
                          UNITTEST_CHECK_WITH_DESCRIPTION(UnitTest::AreClose(expected, actual, tolerance), description))
 
-#define UNITTEST_CHECK_CLOSE(expected, actual, tolerance, test_action)      \
-    UNITTEST_MULTILINE_MACRO_BEGIN \
-        UT_TRY \
-        ({ \
-            test_action; \
-        }) \
-        UT_CATCH (std::exception, e, \
-        { \
-            UnitTest::MemoryOutStream message; \
-            message << "Unhandled exception (" << e.what() << ") in CHECK_CLOSE(" #expected ", " #actual ")"; \
-            UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
-                message.GetText()); \
-        }) \
-        UT_CATCH_ALL \
-        ({ \
-            UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
-                    "Unhandled exception in CHECK_CLOSE(" #expected ", " #actual ")"); \
-        }) \
-    UNITTEST_MULTILINE_MACRO_END
-
 #define CHECK_ARRAY_EQUAL(expected, actual, count) \
     UNITTEST_CHECK_ARRAY_EQUAL(expected, actual, count, \
                                UnitTest::CheckArrayEqual(*UnitTest::CurrentTest::Results(), expected, actual, count, \
@@ -138,26 +69,6 @@
 #define CHECK_ARRAY_EQUAL_DESCRIBED(expected, actual, count, description) \
     UNITTEST_CHECK_ARRAY_EQUAL(expected, actual, count, \
                                UNITTEST_CHECK_WITH_DESCRIPTION(UnitTest::ArrayAreEqual(expected, actual, count), description))
-
-#define UNITTEST_CHECK_ARRAY_EQUAL(expected, actual, count, test_action)    \
-    UNITTEST_MULTILINE_MACRO_BEGIN \
-        UT_TRY \
-        ({ \
-            test_action; \
-        }) \
-        UT_CATCH (std::exception, e, \
-        { \
-            UnitTest::MemoryOutStream message; \
-            message << "Unhandled exception (" << e.what() << ") in CHECK_ARRAY_EQUAL(" #expected ", " #actual ")"; \
-            UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
-                message.GetText()); \
-        }) \
-        UT_CATCH_ALL \
-        ({ \
-            UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
-                    "Unhandled exception in CHECK_ARRAY_EQUAL(" #expected ", " #actual ")"); \
-        }) \
-    UNITTEST_MULTILINE_MACRO_END
 
 #define CHECK_ARRAY_CLOSE(expected, actual, count, tolerance) \
     UNITTEST_CHECK_ARRAY_CLOSE(expected, actual, count, tolerance, \
@@ -168,26 +79,6 @@
     UNITTEST_CHECK_ARRAY_CLOSE(expected, actual, count, tolerance, \
                                UNITTEST_CHECK_WITH_DESCRIPTION(UnitTest::ArrayAreClose(expected, actual, count, tolerance), description))
 
-#define UNITTEST_CHECK_ARRAY_CLOSE(expected, actual, count, tolerance, test_action) \
-    UNITTEST_MULTILINE_MACRO_BEGIN \
-        UT_TRY \
-        ({ \
-            test_action; \
-        }) \
-        UT_CATCH (std::exception, e, \
-        { \
-            UnitTest::MemoryOutStream message; \
-            message << "Unhandled exception (" << e.what() << ") in CHECK_ARRAY_CLOSE(" #expected ", " #actual ")"; \
-            UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
-                message.GetText()); \
-        }) \
-        UT_CATCH_ALL \
-        ({ \
-            UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
-                    "Unhandled exception in CHECK_ARRAY_CLOSE(" #expected ", " #actual ")"); \
-        }) \
-    UNITTEST_MULTILINE_MACRO_END
-
 #define CHECK_ARRAY2D_CLOSE(expected, actual, rows, columns, tolerance) \
     UNITTEST_CHECK_ARRAY2D_CLOSE(expected, actual, rows, columns, tolerance, \
                                  UnitTest::CheckArray2DClose(*UnitTest::CurrentTest::Results(), expected, actual, rows, columns, tolerance, \
@@ -196,26 +87,6 @@
 #define CHECK_ARRAY2D_CLOSE_DESCRIBED(expected, actual, rows, columns, tolerance, description) \
     UNITTEST_CHECK_ARRAY2D_CLOSE(expected, actual, rows, columns, tolerance, \
                                  UNITTEST_CHECK_WITH_DESCRIPTION(UnitTest::Array2DAreClose(expected, actual, rows, columns, tolerance), description))
-
-#define UNITTEST_CHECK_ARRAY2D_CLOSE(expected, actual, rows, columns, tolerance, test_action) \
-    UNITTEST_MULTILINE_MACRO_BEGIN \
-        UT_TRY \
-        ({ \
-            test_action; \
-        }) \
-        UT_CATCH (std::exception, e, \
-        { \
-            UnitTest::MemoryOutStream message; \
-            message << "Unhandled exception (" << e.what() << ") in CHECK_ARRAY2D_CLOSE(" #expected ", " #actual ")"; \
-            UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
-                message.GetText()); \
-        }) \
-        UT_CATCH_ALL \
-        ({ \
-            UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
-                    "Unhandled exception in CHECK_ARRAY2D_CLOSE(" #expected ", " #actual ")"); \
-        }) \
-    UNITTEST_MULTILINE_MACRO_END
 
 // CHECK_THROW and CHECK_ASSERT only exist when UNITTEST_NO_EXCEPTIONS isn't defined (see config.h)
 #ifndef UNITTEST_NO_EXCEPTIONS
@@ -228,18 +99,6 @@
 #define CHECK_THROW_DESCRIBED(expression, ExpectedExceptionType, description) \
     UNITTEST_CHECK_THROW(expression, ExpectedExceptionType, \
                          UNITTEST_CHECK_WITH_DESCRIPTION(false, description))
-
-#define UNITTEST_CHECK_THROW(expression, ExpectedExceptionType, failure_action)        \
-    UNITTEST_MULTILINE_MACRO_BEGIN \
-        bool caught_ = false; \
-        try { expression; } \
-        catch (ExpectedExceptionType const&) { caught_ = true; } \
-        catch (...) {} \
-        if (!caught_) \
-        { \
-            failure_action; \
-        } \
-    UNITTEST_MULTILINE_MACRO_END
 
 #define CHECK_ASSERT(expression) \
     UNITTEST_MULTILINE_MACRO_BEGIN \

--- a/UnitTest++/CheckMacros.h
+++ b/UnitTest++/CheckMacros.h
@@ -35,11 +35,17 @@
 #endif
 
 #define CHECK(value) \
+    UNITTEST_CHECK(value, \
+                   if (!UnitTest::Check(value)) \
+                   { \
+                       UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), #value); \
+                   })
+
+#define UNITTEST_CHECK(value, test_action) \
     UNITTEST_MULTILINE_MACRO_BEGIN \
     UT_TRY \
         ({ \
-            if (!UnitTest::Check(value)) \
-                UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), #value); \
+            test_action; \
         }) \
         UT_CATCH (std::exception, e, \
         { \
@@ -56,10 +62,15 @@
     UNITTEST_MULTILINE_MACRO_END
 
 #define CHECK_EQUAL(expected, actual) \
+    UNITTEST_CHECK_EQUAL(expected, actual, \
+                         UnitTest::CheckEqual(*UnitTest::CurrentTest::Results(), expected, actual, \
+                                              UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__)))
+
+#define UNITTEST_CHECK_EQUAL(expected, actual, test_action) \
     UNITTEST_MULTILINE_MACRO_BEGIN \
         UT_TRY \
         ({ \
-            UnitTest::CheckEqual(*UnitTest::CurrentTest::Results(), expected, actual, UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__)); \
+            test_action; \
         }) \
         UT_CATCH (std::exception, e, \
         { \
@@ -76,10 +87,15 @@
     UNITTEST_MULTILINE_MACRO_END
 
 #define CHECK_CLOSE(expected, actual, tolerance) \
+    UNITTEST_CHECK_CLOSE(expected, actual, tolerance, \
+                         UnitTest::CheckClose(*UnitTest::CurrentTest::Results(), expected, actual, tolerance, \
+                                              UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__)))
+
+#define UNITTEST_CHECK_CLOSE(expected, actual, tolerance, test_action)      \
     UNITTEST_MULTILINE_MACRO_BEGIN \
         UT_TRY \
         ({ \
-            UnitTest::CheckClose(*UnitTest::CurrentTest::Results(), expected, actual, tolerance, UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__)); \
+            test_action; \
         }) \
         UT_CATCH (std::exception, e, \
         { \
@@ -96,10 +112,15 @@
     UNITTEST_MULTILINE_MACRO_END
 
 #define CHECK_ARRAY_EQUAL(expected, actual, count) \
+    UNITTEST_CHECK_ARRAY_EQUAL(expected, actual, count, \
+                               UnitTest::CheckArrayEqual(*UnitTest::CurrentTest::Results(), expected, actual, count, \
+                                                         UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__)))
+
+#define UNITTEST_CHECK_ARRAY_EQUAL(expected, actual, count, test_action)    \
     UNITTEST_MULTILINE_MACRO_BEGIN \
         UT_TRY \
         ({ \
-            UnitTest::CheckArrayEqual(*UnitTest::CurrentTest::Results(), expected, actual, count, UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__)); \
+            test_action; \
         }) \
         UT_CATCH (std::exception, e, \
         { \
@@ -116,10 +137,15 @@
     UNITTEST_MULTILINE_MACRO_END
 
 #define CHECK_ARRAY_CLOSE(expected, actual, count, tolerance) \
+    UNITTEST_CHECK_ARRAY_CLOSE(expected, actual, count, tolerance, \
+                               UnitTest::CheckArrayClose(*UnitTest::CurrentTest::Results(), expected, actual, count, tolerance, \
+                                                         UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__)))
+
+#define UNITTEST_CHECK_ARRAY_CLOSE(expected, actual, count, tolerance, test_action) \
     UNITTEST_MULTILINE_MACRO_BEGIN \
         UT_TRY \
         ({ \
-            UnitTest::CheckArrayClose(*UnitTest::CurrentTest::Results(), expected, actual, count, tolerance, UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__)); \
+            test_action; \
         }) \
         UT_CATCH (std::exception, e, \
         { \
@@ -136,10 +162,15 @@
     UNITTEST_MULTILINE_MACRO_END
 
 #define CHECK_ARRAY2D_CLOSE(expected, actual, rows, columns, tolerance) \
+    UNITTEST_CHECK_ARRAY2D_CLOSE(expected, actual, rows, columns, tolerance, \
+                                 UnitTest::CheckArray2DClose(*UnitTest::CurrentTest::Results(), expected, actual, rows, columns, tolerance, \
+                                                             UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__)))
+
+#define UNITTEST_CHECK_ARRAY2D_CLOSE(expected, actual, rows, columns, tolerance, test_action) \
     UNITTEST_MULTILINE_MACRO_BEGIN \
         UT_TRY \
         ({ \
-            UnitTest::CheckArray2DClose(*UnitTest::CurrentTest::Results(), expected, actual, rows, columns, tolerance, UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__)); \
+            test_action; \
         }) \
         UT_CATCH (std::exception, e, \
         { \
@@ -155,19 +186,25 @@
         }) \
     UNITTEST_MULTILINE_MACRO_END
 
-
 // CHECK_THROW and CHECK_ASSERT only exist when UNITTEST_NO_EXCEPTIONS isn't defined (see config.h)
 #ifndef UNITTEST_NO_EXCEPTIONS
+
 #define CHECK_THROW(expression, ExpectedExceptionType) \
+    UNITTEST_CHECK_THROW(expression, ExpectedExceptionType, \
+                         UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
+                                                                         "Expected exception: \"" #ExpectedExceptionType "\" not thrown"))
+
+#define UNITTEST_CHECK_THROW(expression, ExpectedExceptionType, failure_action)        \
     UNITTEST_MULTILINE_MACRO_BEGIN \
         bool caught_ = false; \
         try { expression; } \
         catch (ExpectedExceptionType const&) { caught_ = true; } \
         catch (...) {} \
         if (!caught_) \
-            UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), "Expected exception: \"" #ExpectedExceptionType "\" not thrown"); \
+        { \
+            failure_action; \
+        } \
     UNITTEST_MULTILINE_MACRO_END
-
 
 #define CHECK_ASSERT(expression) \
     UNITTEST_MULTILINE_MACRO_BEGIN \

--- a/UnitTest++/CheckMacros.h
+++ b/UnitTest++/CheckMacros.h
@@ -247,5 +247,13 @@
         CHECK_THROW(expression, UnitTest::AssertException); \
         UnitTest::Detail::ExpectAssert(false); \
     UNITTEST_MULTILINE_MACRO_END
+
+#define CHECK_ASSERT_DESCRIBED(expression, description) \
+    UNITTEST_MULTILINE_MACRO_BEGIN \
+        UnitTest::Detail::ExpectAssert(true); \
+        CHECK_THROW_DESCRIBED(expression, UnitTest::AssertException, description); \
+        UnitTest::Detail::ExpectAssert(false); \
+    UNITTEST_MULTILINE_MACRO_END
+
 #endif
 #endif

--- a/UnitTest++/CheckMacros.h
+++ b/UnitTest++/CheckMacros.h
@@ -225,6 +225,10 @@
                          UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
                                                                          "Expected exception: \"" #ExpectedExceptionType "\" not thrown"))
 
+#define CHECK_THROW_DESCRIBED(expression, ExpectedExceptionType, description) \
+    UNITTEST_CHECK_THROW(expression, ExpectedExceptionType, \
+                         UNITTEST_CHECK_WITH_DESCRIPTION(false, description))
+
 #define UNITTEST_CHECK_THROW(expression, ExpectedExceptionType, failure_action)        \
     UNITTEST_MULTILINE_MACRO_BEGIN \
         bool caught_ = false; \

--- a/UnitTest++/CheckMacros.h
+++ b/UnitTest++/CheckMacros.h
@@ -106,6 +106,10 @@
                          UnitTest::CheckClose(*UnitTest::CurrentTest::Results(), expected, actual, tolerance, \
                                               UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__)))
 
+#define CHECK_CLOSE_DESCRIBED(expected, actual, tolerance, description) \
+    UNITTEST_CHECK_CLOSE(expected, actual, tolerance, \
+                         UNITTEST_CHECK_WITH_DESCRIPTION(UnitTest::AreClose(expected, actual, tolerance), description))
+
 #define UNITTEST_CHECK_CLOSE(expected, actual, tolerance, test_action)      \
     UNITTEST_MULTILINE_MACRO_BEGIN \
         UT_TRY \

--- a/UnitTest++/CheckMacros.h
+++ b/UnitTest++/CheckMacros.h
@@ -77,6 +77,10 @@
                          UnitTest::CheckEqual(*UnitTest::CurrentTest::Results(), expected, actual, \
                                               UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__)))
 
+#define CHECK_EQUAL_DESCRIBED(expected, actual, description) \
+    UNITTEST_CHECK_EQUAL(expected, actual, \
+                         UNITTEST_CHECK_WITH_DESCRIPTION(UnitTest::AreEqual(expected, actual), description))
+
 #define UNITTEST_CHECK_EQUAL(expected, actual, test_action) \
     UNITTEST_MULTILINE_MACRO_BEGIN \
         UT_TRY \

--- a/UnitTest++/CheckMacros.h
+++ b/UnitTest++/CheckMacros.h
@@ -135,6 +135,10 @@
                                UnitTest::CheckArrayEqual(*UnitTest::CurrentTest::Results(), expected, actual, count, \
                                                          UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__)))
 
+#define CHECK_ARRAY_EQUAL_DESCRIBED(expected, actual, count, description) \
+    UNITTEST_CHECK_ARRAY_EQUAL(expected, actual, count, \
+                               UNITTEST_CHECK_WITH_DESCRIPTION(UnitTest::ArrayAreEqual(expected, actual, count), description))
+
 #define UNITTEST_CHECK_ARRAY_EQUAL(expected, actual, count, test_action)    \
     UNITTEST_MULTILINE_MACRO_BEGIN \
         UT_TRY \

--- a/UnitTest++/CheckMacros.h
+++ b/UnitTest++/CheckMacros.h
@@ -34,12 +34,23 @@
     #error UnitTest++ redefines CHECK_ARRAY2D_CLOSE
 #endif
 
+#define UNITTEST_CHECK_WITH_DESCRIPTION(condition, description) \
+    if (!condition) \
+    { \
+        UnitTest::MemoryOutStream stream; \
+        stream << description; \
+        UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), stream.GetText()); \
+    }
+
 #define CHECK(value) \
     UNITTEST_CHECK(value, \
                    if (!UnitTest::Check(value)) \
                    { \
                        UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), #value); \
                    })
+
+#define CHECK_DESCRIBED(value, description) \
+    UNITTEST_CHECK(value, UNITTEST_CHECK_WITH_DESCRIPTION(UnitTest::Check(value), description))
 
 #define UNITTEST_CHECK(value, test_action) \
     UNITTEST_MULTILINE_MACRO_BEGIN \

--- a/UnitTest++/CheckMacros.h
+++ b/UnitTest++/CheckMacros.h
@@ -193,6 +193,10 @@
                                  UnitTest::CheckArray2DClose(*UnitTest::CurrentTest::Results(), expected, actual, rows, columns, tolerance, \
                                                              UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__)))
 
+#define CHECK_ARRAY2D_CLOSE_DESCRIBED(expected, actual, rows, columns, tolerance, description) \
+    UNITTEST_CHECK_ARRAY2D_CLOSE(expected, actual, rows, columns, tolerance, \
+                                 UNITTEST_CHECK_WITH_DESCRIPTION(UnitTest::Array2DAreClose(expected, actual, rows, columns, tolerance), description))
+
 #define UNITTEST_CHECK_ARRAY2D_CLOSE(expected, actual, rows, columns, tolerance, test_action) \
     UNITTEST_MULTILINE_MACRO_BEGIN \
         UT_TRY \

--- a/UnitTest++/CheckMacros.h
+++ b/UnitTest++/CheckMacros.h
@@ -1,4 +1,4 @@
-#ifndef UNITTEST_CHECKMACROS_H 
+#ifndef UNITTEST_CHECKMACROS_H
 #define UNITTEST_CHECKMACROS_H
 
 #include "HelperMacros.h"
@@ -15,165 +15,165 @@
 #endif
 
 #ifdef CHECK_EQUAL
-	#error UnitTest++ redefines CHECK_EQUAL
+    #error UnitTest++ redefines CHECK_EQUAL
 #endif
 
 #ifdef CHECK_CLOSE
-	#error UnitTest++ redefines CHECK_CLOSE
+    #error UnitTest++ redefines CHECK_CLOSE
 #endif
 
 #ifdef CHECK_ARRAY_EQUAL
-	#error UnitTest++ redefines CHECK_ARRAY_EQUAL
+    #error UnitTest++ redefines CHECK_ARRAY_EQUAL
 #endif
 
 #ifdef CHECK_ARRAY_CLOSE
-	#error UnitTest++ redefines CHECK_ARRAY_CLOSE
+    #error UnitTest++ redefines CHECK_ARRAY_CLOSE
 #endif
 
 #ifdef CHECK_ARRAY2D_CLOSE
-	#error UnitTest++ redefines CHECK_ARRAY2D_CLOSE
+    #error UnitTest++ redefines CHECK_ARRAY2D_CLOSE
 #endif
 
 #define CHECK(value) \
-	UNITTEST_MULTILINE_MACRO_BEGIN \
-	UT_TRY \
-		({ \
-			if (!UnitTest::Check(value)) \
-				UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), #value); \
-		}) \
-		UT_CATCH (std::exception, e, \
-		{ \
-			UnitTest::MemoryOutStream message; \
-			message << "Unhandled exception (" << e.what() << ") in CHECK(" #value ")"; \
-			UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
-				message.GetText()); \
-		}) \
-		UT_CATCH_ALL \
-		({ \
-			UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
-				"Unhandled exception in CHECK(" #value ")"); \
-		}) \
-	UNITTEST_MULTILINE_MACRO_END
+    UNITTEST_MULTILINE_MACRO_BEGIN \
+    UT_TRY \
+        ({ \
+            if (!UnitTest::Check(value)) \
+                UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), #value); \
+        }) \
+        UT_CATCH (std::exception, e, \
+        { \
+            UnitTest::MemoryOutStream message; \
+            message << "Unhandled exception (" << e.what() << ") in CHECK(" #value ")"; \
+            UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
+                message.GetText()); \
+        }) \
+        UT_CATCH_ALL \
+        ({ \
+            UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
+                "Unhandled exception in CHECK(" #value ")"); \
+        }) \
+    UNITTEST_MULTILINE_MACRO_END
 
 #define CHECK_EQUAL(expected, actual) \
-	UNITTEST_MULTILINE_MACRO_BEGIN \
+    UNITTEST_MULTILINE_MACRO_BEGIN \
         UT_TRY \
-		({ \
+        ({ \
             UnitTest::CheckEqual(*UnitTest::CurrentTest::Results(), expected, actual, UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__)); \
         }) \
-		UT_CATCH (std::exception, e, \
-		{ \
-			UnitTest::MemoryOutStream message; \
-			message << "Unhandled exception (" << e.what() << ") in CHECK_EQUAL(" #expected ", " #actual ")"; \
-			UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
-				message.GetText()); \
-		}) \
+        UT_CATCH (std::exception, e, \
+        { \
+            UnitTest::MemoryOutStream message; \
+            message << "Unhandled exception (" << e.what() << ") in CHECK_EQUAL(" #expected ", " #actual ")"; \
+            UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
+                message.GetText()); \
+        }) \
         UT_CATCH_ALL \
-		({ \
+        ({ \
             UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
                     "Unhandled exception in CHECK_EQUAL(" #expected ", " #actual ")"); \
         }) \
-	UNITTEST_MULTILINE_MACRO_END
+    UNITTEST_MULTILINE_MACRO_END
 
 #define CHECK_CLOSE(expected, actual, tolerance) \
-	UNITTEST_MULTILINE_MACRO_BEGIN \
+    UNITTEST_MULTILINE_MACRO_BEGIN \
         UT_TRY \
-		({ \
+        ({ \
             UnitTest::CheckClose(*UnitTest::CurrentTest::Results(), expected, actual, tolerance, UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__)); \
         }) \
-		UT_CATCH (std::exception, e, \
-		{ \
-			UnitTest::MemoryOutStream message; \
-			message << "Unhandled exception (" << e.what() << ") in CHECK_CLOSE(" #expected ", " #actual ")"; \
-			UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
-				message.GetText()); \
-		}) \
+        UT_CATCH (std::exception, e, \
+        { \
+            UnitTest::MemoryOutStream message; \
+            message << "Unhandled exception (" << e.what() << ") in CHECK_CLOSE(" #expected ", " #actual ")"; \
+            UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
+                message.GetText()); \
+        }) \
         UT_CATCH_ALL \
-		({ \
+        ({ \
             UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
                     "Unhandled exception in CHECK_CLOSE(" #expected ", " #actual ")"); \
         }) \
-	UNITTEST_MULTILINE_MACRO_END
+    UNITTEST_MULTILINE_MACRO_END
 
 #define CHECK_ARRAY_EQUAL(expected, actual, count) \
-	UNITTEST_MULTILINE_MACRO_BEGIN \
+    UNITTEST_MULTILINE_MACRO_BEGIN \
         UT_TRY \
-		({ \
+        ({ \
             UnitTest::CheckArrayEqual(*UnitTest::CurrentTest::Results(), expected, actual, count, UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__)); \
         }) \
- 		UT_CATCH (std::exception, e, \
-		{ \
-			UnitTest::MemoryOutStream message; \
-			message << "Unhandled exception (" << e.what() << ") in CHECK_ARRAY_EQUAL(" #expected ", " #actual ")"; \
-			UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
-				message.GetText()); \
-		}) \
+        UT_CATCH (std::exception, e, \
+        { \
+            UnitTest::MemoryOutStream message; \
+            message << "Unhandled exception (" << e.what() << ") in CHECK_ARRAY_EQUAL(" #expected ", " #actual ")"; \
+            UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
+                message.GetText()); \
+        }) \
         UT_CATCH_ALL \
-		({ \
+        ({ \
             UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
                     "Unhandled exception in CHECK_ARRAY_EQUAL(" #expected ", " #actual ")"); \
         }) \
-	UNITTEST_MULTILINE_MACRO_END
+    UNITTEST_MULTILINE_MACRO_END
 
 #define CHECK_ARRAY_CLOSE(expected, actual, count, tolerance) \
-	UNITTEST_MULTILINE_MACRO_BEGIN \
+    UNITTEST_MULTILINE_MACRO_BEGIN \
         UT_TRY \
-		({ \
+        ({ \
             UnitTest::CheckArrayClose(*UnitTest::CurrentTest::Results(), expected, actual, count, tolerance, UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__)); \
         }) \
- 		UT_CATCH (std::exception, e, \
-		{ \
-			UnitTest::MemoryOutStream message; \
-			message << "Unhandled exception (" << e.what() << ") in CHECK_ARRAY_CLOSE(" #expected ", " #actual ")"; \
-			UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
-				message.GetText()); \
-		}) \
+        UT_CATCH (std::exception, e, \
+        { \
+            UnitTest::MemoryOutStream message; \
+            message << "Unhandled exception (" << e.what() << ") in CHECK_ARRAY_CLOSE(" #expected ", " #actual ")"; \
+            UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
+                message.GetText()); \
+        }) \
         UT_CATCH_ALL \
-		({ \
+        ({ \
             UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
                     "Unhandled exception in CHECK_ARRAY_CLOSE(" #expected ", " #actual ")"); \
         }) \
-	UNITTEST_MULTILINE_MACRO_END
+    UNITTEST_MULTILINE_MACRO_END
 
 #define CHECK_ARRAY2D_CLOSE(expected, actual, rows, columns, tolerance) \
-	UNITTEST_MULTILINE_MACRO_BEGIN \
+    UNITTEST_MULTILINE_MACRO_BEGIN \
         UT_TRY \
-		({ \
+        ({ \
             UnitTest::CheckArray2DClose(*UnitTest::CurrentTest::Results(), expected, actual, rows, columns, tolerance, UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__)); \
         }) \
- 		UT_CATCH (std::exception, e, \
-		{ \
-			UnitTest::MemoryOutStream message; \
-			message << "Unhandled exception (" << e.what() << ") in CHECK_ARRAY2D_CLOSE(" #expected ", " #actual ")"; \
-			UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
-				message.GetText()); \
-		}) \
+        UT_CATCH (std::exception, e, \
+        { \
+            UnitTest::MemoryOutStream message; \
+            message << "Unhandled exception (" << e.what() << ") in CHECK_ARRAY2D_CLOSE(" #expected ", " #actual ")"; \
+            UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
+                message.GetText()); \
+        }) \
         UT_CATCH_ALL \
-		({ \
+        ({ \
             UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), \
                     "Unhandled exception in CHECK_ARRAY2D_CLOSE(" #expected ", " #actual ")"); \
         }) \
-	UNITTEST_MULTILINE_MACRO_END
+    UNITTEST_MULTILINE_MACRO_END
 
 
 // CHECK_THROW and CHECK_ASSERT only exist when UNITTEST_NO_EXCEPTIONS isn't defined (see config.h)
 #ifndef UNITTEST_NO_EXCEPTIONS
 #define CHECK_THROW(expression, ExpectedExceptionType) \
-	UNITTEST_MULTILINE_MACRO_BEGIN \
+    UNITTEST_MULTILINE_MACRO_BEGIN \
         bool caught_ = false; \
         try { expression; } \
         catch (ExpectedExceptionType const&) { caught_ = true; } \
-		catch (...) {} \
+        catch (...) {} \
         if (!caught_) \
-	        UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), "Expected exception: \"" #ExpectedExceptionType "\" not thrown"); \
-	UNITTEST_MULTILINE_MACRO_END
+            UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), "Expected exception: \"" #ExpectedExceptionType "\" not thrown"); \
+    UNITTEST_MULTILINE_MACRO_END
 
 
 #define CHECK_ASSERT(expression) \
-	UNITTEST_MULTILINE_MACRO_BEGIN \
-		UnitTest::Detail::ExpectAssert(true); \
-		CHECK_THROW(expression, UnitTest::AssertException); \
-		UnitTest::Detail::ExpectAssert(false); \
-	UNITTEST_MULTILINE_MACRO_END
+    UNITTEST_MULTILINE_MACRO_BEGIN \
+        UnitTest::Detail::ExpectAssert(true); \
+        CHECK_THROW(expression, UnitTest::AssertException); \
+        UnitTest::Detail::ExpectAssert(false); \
+    UNITTEST_MULTILINE_MACRO_END
 #endif
 #endif

--- a/UnitTest++/Checks.cpp
+++ b/UnitTest++/Checks.cpp
@@ -5,12 +5,17 @@ namespace UnitTest {
 
 namespace {
 
+bool StringsAreEqual(char const* expected, char const* actual)
+{
+    return !((expected && actual) ? strcmp(expected, actual) : (expected || actual));
+}
+
 void CheckStringsEqual(TestResults& results, char const* expected, char const* actual,
                        TestDetails const& details)
 {
     using namespace std;
 
-    if ((expected && actual) ? strcmp(expected, actual) : (expected || actual))
+    if (!StringsAreEqual(expected, actual))
     {
         UnitTest::MemoryOutStream stream;
         stream << "Expected " << (expected ? expected : "<NULLPTR>") << " but was " << (actual ? actual : "<NULLPTR>");
@@ -21,6 +26,10 @@ void CheckStringsEqual(TestResults& results, char const* expected, char const* a
 
 }
 
+bool AreEqual(char const* expected, char const* actual)
+{
+    return StringsAreEqual(expected, actual);
+}
 
 void CheckEqual(TestResults& results, char const* expected, char const* actual,
                 TestDetails const& details)
@@ -28,10 +37,19 @@ void CheckEqual(TestResults& results, char const* expected, char const* actual,
     CheckStringsEqual(results, expected, actual, details);
 }
 
+bool AreEqual(char* expected, char* actual)
+{
+    return StringsAreEqual(expected, actual);
+}
+
 void CheckEqual(TestResults& results, char* expected, char* actual,
                 TestDetails const& details)
 {
     CheckStringsEqual(results, expected, actual, details);
+}
+bool AreEqual(char* expected, char const* actual)
+{
+    return StringsAreEqual(expected, actual);
 }
 
 void CheckEqual(TestResults& results, char* expected, char const* actual,
@@ -40,11 +58,15 @@ void CheckEqual(TestResults& results, char* expected, char const* actual,
     CheckStringsEqual(results, expected, actual, details);
 }
 
+bool AreEqual(char const* expected, char* actual)
+{
+    return StringsAreEqual(expected, actual);
+}
+
 void CheckEqual(TestResults& results, char const* expected, char* actual,
                 TestDetails const& details)
 {
     CheckStringsEqual(results, expected, actual, details);
 }
-
 
 }

--- a/UnitTest++/Checks.cpp
+++ b/UnitTest++/Checks.cpp
@@ -5,10 +5,10 @@ namespace UnitTest {
 
 namespace {
 
-void CheckStringsEqual(TestResults& results, char const* expected, char const* actual, 
+void CheckStringsEqual(TestResults& results, char const* expected, char const* actual,
                        TestDetails const& details)
 {
-	using namespace std;
+    using namespace std;
 
     if ((expected && actual) ? strcmp(expected, actual) : (expected || actual))
     {

--- a/UnitTest++/Checks.h
+++ b/UnitTest++/Checks.h
@@ -46,7 +46,7 @@ void CheckClose(TestResults& results, Expected const& expected, Actual const& ac
                 TestDetails const& details)
 {
     if (!AreClose(expected, actual, tolerance))
-    { 
+    {
         UnitTest::MemoryOutStream stream;
         stream << "Expected " << expected << " +/- " << tolerance << " but was " << actual;
 
@@ -57,7 +57,7 @@ void CheckClose(TestResults& results, Expected const& expected, Actual const& ac
 
 template< typename Expected, typename Actual >
 void CheckArrayEqual(TestResults& results, Expected const& expected, Actual const& actual,
-                int const count, TestDetails const& details)
+                     int const count, TestDetails const& details)
 {
     bool equal = true;
     for (int i = 0; i < count; ++i)
@@ -67,17 +67,17 @@ void CheckArrayEqual(TestResults& results, Expected const& expected, Actual cons
     {
         UnitTest::MemoryOutStream stream;
 
-		stream << "Expected [ ";
+        stream << "Expected [ ";
 
-		for (int expectedIndex = 0; expectedIndex < count; ++expectedIndex)
+        for (int expectedIndex = 0; expectedIndex < count; ++expectedIndex)
             stream << expected[expectedIndex] << " ";
 
-		stream << "] but was [ ";
+        stream << "] but was [ ";
 
-		for (int actualIndex = 0; actualIndex < count; ++actualIndex)
+        for (int actualIndex = 0; actualIndex < count; ++actualIndex)
             stream << actual[actualIndex] << " ";
 
-		stream << "]";
+        stream << "]";
 
         results.OnTestFailure(details, stream.GetText());
     }
@@ -94,7 +94,7 @@ bool ArrayAreClose(Expected const& expected, Actual const& actual, int const cou
 
 template< typename Expected, typename Actual, typename Tolerance >
 void CheckArrayClose(TestResults& results, Expected const& expected, Actual const& actual,
-                   int const count, Tolerance const& tolerance, TestDetails const& details)
+                     int const count, Tolerance const& tolerance, TestDetails const& details)
 {
     bool equal = ArrayAreClose(expected, actual, count, tolerance);
 
@@ -107,7 +107,7 @@ void CheckArrayClose(TestResults& results, Expected const& expected, Actual cons
             stream << expected[expectedIndex] << " ";
         stream << "] +/- " << tolerance << " but was [ ";
 
-		for (int actualIndex = 0; actualIndex < count; ++actualIndex)
+        for (int actualIndex = 0; actualIndex < count; ++actualIndex)
             stream << actual[actualIndex] << " ";
         stream << "]";
 
@@ -117,7 +117,7 @@ void CheckArrayClose(TestResults& results, Expected const& expected, Actual cons
 
 template< typename Expected, typename Actual, typename Tolerance >
 void CheckArray2DClose(TestResults& results, Expected const& expected, Actual const& actual,
-                   int const rows, int const columns, Tolerance const& tolerance, TestDetails const& details)
+                       int const rows, int const columns, Tolerance const& tolerance, TestDetails const& details)
 {
     bool equal = true;
     for (int i = 0; i < rows; ++i)
@@ -127,9 +127,9 @@ void CheckArray2DClose(TestResults& results, Expected const& expected, Actual co
     {
         UnitTest::MemoryOutStream stream;
 
-        stream << "Expected [ ";    
+        stream << "Expected [ ";
 
-		for (int expectedRow = 0; expectedRow < rows; ++expectedRow)
+        for (int expectedRow = 0; expectedRow < rows; ++expectedRow)
         {
             stream << "[ ";
             for (int expectedColumn = 0; expectedColumn < columns; ++expectedColumn)
@@ -137,9 +137,9 @@ void CheckArray2DClose(TestResults& results, Expected const& expected, Actual co
             stream << "] ";
         }
 
-		stream << "] +/- " << tolerance << " but was [ ";
+        stream << "] +/- " << tolerance << " but was [ ";
 
-		for (int actualRow = 0; actualRow < rows; ++actualRow)
+        for (int actualRow = 0; actualRow < rows; ++actualRow)
         {
             stream << "[ ";
             for (int actualColumn = 0; actualColumn < columns; ++actualColumn)
@@ -147,7 +147,7 @@ void CheckArray2DClose(TestResults& results, Expected const& expected, Actual co
             stream << "] ";
         }
 
-		stream << "]";
+        stream << "]";
 
         results.OnTestFailure(details, stream.GetText());
     }

--- a/UnitTest++/Checks.h
+++ b/UnitTest++/Checks.h
@@ -16,9 +16,15 @@ bool Check(Value const value)
 
 
 template< typename Expected, typename Actual >
+bool AreEqual(Expected const& expected, Actual const& actual)
+{
+    return expected == actual;
+}
+
+template< typename Expected, typename Actual >
 void CheckEqual(TestResults& results, Expected const& expected, Actual const& actual, TestDetails const& details)
 {
-    if (!(expected == actual))
+    if (!AreEqual(expected, actual))
     {
         UnitTest::MemoryOutStream stream;
         stream << "Expected " << expected << " but was " << actual;
@@ -27,13 +33,18 @@ void CheckEqual(TestResults& results, Expected const& expected, Actual const& ac
     }
 }
 
+UNITTEST_LINKAGE bool AreEqual(char const* expected, char const* actual);
 UNITTEST_LINKAGE void CheckEqual(TestResults& results, char const* expected, char const* actual, TestDetails const& details);
 
+UNITTEST_LINKAGE bool AreEqual(char* expected, char* actual);
 UNITTEST_LINKAGE void CheckEqual(TestResults& results, char* expected, char* actual, TestDetails const& details);
 
+UNITTEST_LINKAGE bool AreEqual(char* expected, char const* actual);
 UNITTEST_LINKAGE void CheckEqual(TestResults& results, char* expected, char const* actual, TestDetails const& details);
 
+UNITTEST_LINKAGE bool AreEqual(char const* expected, char* actual);
 UNITTEST_LINKAGE void CheckEqual(TestResults& results, char const* expected, char* actual, TestDetails const& details);
+
 
 template< typename Expected, typename Actual, typename Tolerance >
 bool AreClose(Expected const& expected, Actual const& actual, Tolerance const& tolerance)
@@ -54,16 +65,21 @@ void CheckClose(TestResults& results, Expected const& expected, Actual const& ac
     }
 }
 
-
 template< typename Expected, typename Actual >
-void CheckArrayEqual(TestResults& results, Expected const& expected, Actual const& actual,
-                     int const count, TestDetails const& details)
+bool ArrayAreEqual(Expected const& expected, Actual const& actual, int const count)
 {
     bool equal = true;
     for (int i = 0; i < count; ++i)
         equal &= (expected[i] == actual[i]);
 
-    if (!equal)
+    return equal;
+}
+
+template< typename Expected, typename Actual >
+void CheckArrayEqual(TestResults& results, Expected const& expected, Actual const& actual,
+                     int const count, TestDetails const& details)
+{
+    if (!ArrayAreEqual(expected, actual, count))
     {
         UnitTest::MemoryOutStream stream;
 
@@ -115,15 +131,24 @@ void CheckArrayClose(TestResults& results, Expected const& expected, Actual cons
     }
 }
 
+
 template< typename Expected, typename Actual, typename Tolerance >
-void CheckArray2DClose(TestResults& results, Expected const& expected, Actual const& actual,
-                       int const rows, int const columns, Tolerance const& tolerance, TestDetails const& details)
+bool Array2DAreClose(Expected const& expected, Actual const& actual,
+                     int const rows, int const columns, Tolerance const& tolerance)
 {
     bool equal = true;
     for (int i = 0; i < rows; ++i)
         equal &= ArrayAreClose(expected[i], actual[i], columns, tolerance);
 
-    if (!equal)
+    return equal;
+}
+
+template< typename Expected, typename Actual, typename Tolerance >
+void CheckArray2DClose(TestResults& results, Expected const& expected, Actual const& actual,
+                       int const rows, int const columns, Tolerance const& tolerance, TestDetails const& details)
+{
+
+    if (!Array2DAreClose(expected, actual, rows, columns, tolerance))
     {
         UnitTest::MemoryOutStream stream;
 

--- a/tests/TestCheckMacros.cpp
+++ b/tests/TestCheckMacros.cpp
@@ -1,3 +1,4 @@
+#include <ios>
 #include "UnitTest++/UnitTestPP.h"
 #include "UnitTest++/CurrentTest.h"
 #include "UnitTest++/Config.h"
@@ -88,6 +89,82 @@ TEST(CheckDoesNotHaveSideEffectsWhenFailing)
         UnitTest::TestResults testResults;
         ScopedCurrentTest scopedResults(testResults);
         CHECK(!FunctionWithSideEffects());
+    }
+    CHECK_EQUAL(1, g_sideEffect);
+}
+
+TEST(CheckDescribedSucceedsOnTrue)
+{
+    bool failure = true;
+    {
+        RecordingReporter reporter;
+        UnitTest::TestResults testResults(&reporter);
+
+        ScopedCurrentTest scopedResults(testResults);
+        CHECK_DESCRIBED(true, "description");
+
+        failure = (testResults.GetFailureCount() > 0);
+    }
+
+    CHECK(!failure);
+}
+
+TEST(CheckDescribedFailsOnFalse)
+{
+    bool failure = false;
+    {
+        RecordingReporter reporter;
+        UnitTest::TestResults testResults(&reporter);
+        ScopedCurrentTest scopedResults(testResults);
+        CHECK_DESCRIBED(false, "description");
+        failure = (testResults.GetFailureCount() > 0);
+    }
+
+    CHECK(failure);
+}
+
+TEST(CheckDescribedFailureReportsCorrectTestName)
+{
+    RecordingReporter reporter;
+    {
+        UnitTest::TestResults testResults(&reporter);
+        ScopedCurrentTest scopedResults(testResults);
+        CHECK_DESCRIBED(false, "description");
+    }
+
+    CHECK_EQUAL(m_details.testName, reporter.lastFailedTest);
+}
+
+TEST(CheckDescribedFailureIncludesCustomDescription)
+{
+    RecordingReporter reporter;
+    {
+        UnitTest::TestResults testResults(&reporter);
+        ScopedCurrentTest scopedResults(testResults);
+        CHECK_DESCRIBED(false, "description " << hex << 0x1234);
+    }
+
+    CHECK(strstr(reporter.lastFailedMessage, "description 1234"));
+}
+
+TEST(CheckDescribedDoesNotHaveSideEffectsWhenPassing)
+{
+    g_sideEffect = 0;
+    {
+        UnitTest::TestResults testResults;
+        ScopedCurrentTest scopedResults(testResults);
+        CHECK_DESCRIBED(FunctionWithSideEffects(), "description");
+    }
+    CHECK_EQUAL(1, g_sideEffect);
+}
+
+TEST(CheckDescribedDoesNotHaveSideEffectsWhenFailing)
+{
+    g_sideEffect = 0;
+    {
+        UnitTest::TestResults testResults;
+        ScopedCurrentTest scopedResults(testResults);
+        CHECK_DESCRIBED(!FunctionWithSideEffects(), "description");
     }
     CHECK_EQUAL(1, g_sideEffect);
 }

--- a/tests/TestCheckMacros.cpp
+++ b/tests/TestCheckMacros.cpp
@@ -374,6 +374,75 @@ TEST(CheckCloseDoesNotHaveSideEffectsWhenFailing)
     CHECK_EQUAL(1, g_sideEffect);
 }
 
+TEST(CheckCloseDescribedSucceedsOnEqual)
+{
+    bool failure = true;
+    {
+        RecordingReporter reporter;
+        UnitTest::TestResults testResults(&reporter);
+        ScopedCurrentTest scopedResults(testResults);
+        CHECK_CLOSE_DESCRIBED(1.0f, 1.001f, 0.01f, "description");
+        failure = (testResults.GetFailureCount() > 0);
+    }
+
+    CHECK(!failure);
+}
+
+TEST(CheckCloseDescribedFailsOnNotEqual)
+{
+    bool failure = false;
+    {
+        RecordingReporter reporter;
+        UnitTest::TestResults testResults(&reporter);
+        ScopedCurrentTest scopedResults(testResults);
+        CHECK_CLOSE_DESCRIBED(1.0f, 1.1f, 0.01f, "description");
+        failure = (testResults.GetFailureCount() > 0);
+    }
+
+    CHECK(failure);
+}
+
+TEST(CheckCloseDescribedFailureContainsCorrectDetails)
+{
+    int line = 0;
+    RecordingReporter reporter;
+    {
+        UnitTest::TestResults testResults(&reporter);
+        UnitTest::TestDetails testDetails("test", "suite", "filename", -1);
+        ScopedCurrentTest scopedResults(testResults, &testDetails);
+
+        CHECK_CLOSE_DESCRIBED(1.0f, 1.1f, 0.01f, "description " << hex << 0x1234);    line = __LINE__;
+    }
+
+    CHECK_EQUAL("test", reporter.lastFailedTest);
+    CHECK_EQUAL("suite", reporter.lastFailedSuite);
+    CHECK_EQUAL("filename", reporter.lastFailedFile);
+    CHECK_EQUAL("description 1234", reporter.lastFailedMessage);
+    CHECK_EQUAL(line, reporter.lastFailedLine);
+}
+
+TEST(CheckCloseDescribedDoesNotHaveSideEffectsWhenPassing)
+{
+    g_sideEffect = 0;
+    {
+        UnitTest::TestResults testResults;
+        ScopedCurrentTest scopedResults(testResults);
+        CHECK_CLOSE_DESCRIBED(1, FunctionWithSideEffects(), 0.1f, "description");
+    }
+    CHECK_EQUAL(1, g_sideEffect);
+}
+
+TEST(CheckCloseDescribedDoesNotHaveSideEffectsWhenFailing)
+{
+    g_sideEffect = 0;
+    {
+        UnitTest::TestResults testResults;
+        ScopedCurrentTest scopedResults(testResults);
+        CHECK_CLOSE_DESCRIBED(2, FunctionWithSideEffects(), 0.1f, "description");
+    }
+    CHECK_EQUAL(1, g_sideEffect);
+}
+
 TEST(CheckArrayEqualSuceedsOnEqual)
 {
     bool failure = true;

--- a/tests/TestCheckMacros.cpp
+++ b/tests/TestCheckMacros.cpp
@@ -237,6 +237,74 @@ TEST(CheckEqualDoesNotHaveSideEffectsWhenFailing)
     CHECK_EQUAL(1, g_sideEffect);
 }
 
+TEST(CheckEqualDescribedSucceedsOnEqual)
+{
+    bool failure = true;
+    {
+        RecordingReporter reporter;
+        UnitTest::TestResults testResults(&reporter);
+        ScopedCurrentTest scopedResults(testResults);
+        CHECK_EQUAL_DESCRIBED(1, 1, "description");
+        failure = (testResults.GetFailureCount() > 0);
+    }
+
+    CHECK(!failure);
+}
+
+TEST(CheckEqualDescribedFailsOnNotEqual)
+{
+    bool failure = false;
+    {
+        RecordingReporter reporter;
+        UnitTest::TestResults testResults(&reporter);
+        ScopedCurrentTest scopedResults(testResults);
+        CHECK_EQUAL_DESCRIBED(1, 2, "description");
+        failure = (testResults.GetFailureCount() > 0);
+    }
+
+    CHECK(failure);
+}
+
+TEST(CheckEqualDescribedFailureContainsCorrectDetails)
+{
+    int line = 0;
+    RecordingReporter reporter;
+    {
+        UnitTest::TestResults testResults(&reporter);
+        UnitTest::TestDetails const testDetails("testName", "suiteName", "filename", -1);
+        ScopedCurrentTest scopedResults(testResults, &testDetails);
+
+        CHECK_EQUAL_DESCRIBED(1, 123, "description " << hex << 0x1234);    line = __LINE__;
+    }
+
+    CHECK_EQUAL("testName", reporter.lastFailedTest);
+    CHECK_EQUAL("suiteName", reporter.lastFailedSuite);
+    CHECK_EQUAL("filename", reporter.lastFailedFile);
+    CHECK_EQUAL("description 1234", reporter.lastFailedMessage);
+    CHECK_EQUAL(line, reporter.lastFailedLine);
+}
+
+TEST(CheckEqualDescribedDoesNotHaveSideEffectsWhenPassing)
+{
+    g_sideEffect = 0;
+    {
+        UnitTest::TestResults testResults;
+        ScopedCurrentTest scopedResults(testResults);
+        CHECK_EQUAL_DESCRIBED(1, FunctionWithSideEffects(), "description");
+    }
+    CHECK_EQUAL(1, g_sideEffect);
+}
+
+TEST(CheckEqualDescribedDoesNotHaveSideEffectsWhenFailing)
+{
+    g_sideEffect = 0;
+    {
+        UnitTest::TestResults testResults;
+        ScopedCurrentTest scopedResults(testResults);
+        CHECK_EQUAL_DESCRIBED(2, FunctionWithSideEffects(), "description");
+    }
+    CHECK_EQUAL(1, g_sideEffect);
+}
 
 TEST(CheckCloseSucceedsOnEqual)
 {

--- a/tests/TestCheckMacros.cpp
+++ b/tests/TestCheckMacros.cpp
@@ -742,6 +742,87 @@ TEST(CheckArrayCloseDoesNotHaveSideEffectsWhenFailing)
     CHECK_EQUAL(1, g_sideEffect);
 }
 
+TEST(CheckArrayCloseDescribedSucceedsOnEqual)
+{
+    bool failure = true;
+    {
+        RecordingReporter reporter;
+        UnitTest::TestResults testResults(&reporter);
+        ScopedCurrentTest scopedResults(testResults);
+        const float data[4] = { 0, 1, 2, 3 };
+        CHECK_ARRAY_CLOSE_DESCRIBED(data, data, 4, 0.01f, "description");
+        failure = (testResults.GetFailureCount() > 0);
+    }
+
+    CHECK(!failure);
+}
+
+TEST(CheckArrayCloseDescribedFailsOnNotEqual)
+{
+    bool failure = false;
+    {
+        RecordingReporter reporter;
+        UnitTest::TestResults testResults(&reporter);
+        ScopedCurrentTest scopedResults(testResults);
+
+        int const data1[4] = { 0, 1, 2, 3 };
+        int const data2[4] = { 0, 1, 3, 3 };
+        CHECK_ARRAY_CLOSE_DESCRIBED(data1, data2, 4, 0.01f, "description");
+
+        failure = (testResults.GetFailureCount() > 0);
+    }
+
+    CHECK(failure);
+}
+
+TEST(CheckArrayCloseDescribedFailureContainsCorrectDetails)
+{
+    int line = 0;
+    RecordingReporter reporter;
+    {
+        UnitTest::TestResults testResults(&reporter);
+        UnitTest::TestDetails testDetails("arrayCloseTest", "arrayCloseSuite", "filename", -1);
+        ScopedCurrentTest scopedResults(testResults, &testDetails);
+
+        int const data1[4] = { 0, 1, 2, 3 };
+        int const data2[4] = { 0, 1, 3, 3 };
+        CHECK_ARRAY_CLOSE_DESCRIBED(data1, data2, 4, 0.01f, "description " << hex << 0x1234); line = __LINE__;
+    }
+
+    CHECK_EQUAL("arrayCloseTest", reporter.lastFailedTest);
+    CHECK_EQUAL("arrayCloseSuite", reporter.lastFailedSuite);
+    CHECK_EQUAL("filename", reporter.lastFailedFile);
+    CHECK_EQUAL("description 1234", reporter.lastFailedMessage);
+    CHECK_EQUAL(line, reporter.lastFailedLine);
+}
+
+TEST(CheckArrayCloseDescribedDoesNotHaveSideEffectsWhenPassing)
+{
+    g_sideEffect = 0;
+    {
+        UnitTest::TestResults testResults;
+        ScopedCurrentTest scopedResults(testResults);
+
+        const float data[] = { 0, 1, 2, 3 };
+        CHECK_ARRAY_CLOSE_DESCRIBED(data, FunctionWithSideEffects2(), 4, 0.01f, "description");
+    }
+    CHECK_EQUAL(1, g_sideEffect);
+}
+
+TEST(CheckArrayCloseDescribedDoesNotHaveSideEffectsWhenFailing)
+{
+    g_sideEffect = 0;
+    {
+        UnitTest::TestResults testResults;
+        ScopedCurrentTest scopedResults(testResults);
+
+        const float data[] = { 0, 1, 3, 3 };
+        CHECK_ARRAY_CLOSE_DESCRIBED(data, FunctionWithSideEffects2(), 4, 0.01f, "description");
+    }
+
+    CHECK_EQUAL(1, g_sideEffect);
+}
+
 TEST(CheckArray2DCloseSucceedsOnEqual)
 {
     bool failure = true;

--- a/tests/TestCheckMacros.cpp
+++ b/tests/TestCheckMacros.cpp
@@ -305,6 +305,33 @@ float const* FunctionWithSideEffects2()
     return data;
 }
 
+TEST(CheckArrayEqualDoesNotHaveSideEffectsWhenPassing)
+{
+    g_sideEffect = 0;
+    {
+        UnitTest::TestResults testResults;
+        ScopedCurrentTest scopedResults(testResults);
+
+        const float data[] = { 0, 1, 2, 3 };
+        CHECK_ARRAY_EQUAL (data, FunctionWithSideEffects2(), 4);
+    }
+    CHECK_EQUAL(1, g_sideEffect);
+}
+
+TEST(CheckArrayEqualDoesNotHaveSideEffectsWhenFailing)
+{
+    g_sideEffect = 0;
+    {
+        UnitTest::TestResults testResults;
+        ScopedCurrentTest scopedResults(testResults);
+
+        const float data[] = { 0, 1, 3, 3 };
+        CHECK_ARRAY_EQUAL (data, FunctionWithSideEffects2(), 4);
+    }
+
+    CHECK_EQUAL(1, g_sideEffect);
+}
+
 TEST(CheckArrayCloseSucceedsOnEqual)
 {
     bool failure = true;

--- a/tests/TestCheckMacros.cpp
+++ b/tests/TestCheckMacros.cpp
@@ -7,6 +7,13 @@ using namespace std;
 
 namespace {
 
+int g_sideEffect = 0;
+int FunctionWithSideEffects()
+{
+    ++g_sideEffect;
+    return 1;
+}
+
 TEST(CheckSucceedsOnTrue)
 {
     bool failure = true;
@@ -62,6 +69,28 @@ TEST(CheckFailureIncludesCheckContents)
     CHECK(strstr(reporter.lastFailedMessage, "yaddayadda"));
 }
 
+TEST(CheckDoesNotHaveSideEffectsWhenPassing)
+{
+    g_sideEffect = 0;
+    {
+        UnitTest::TestResults testResults;
+        ScopedCurrentTest scopedResults(testResults);
+        CHECK(FunctionWithSideEffects());
+    }
+    CHECK_EQUAL(1, g_sideEffect);
+}
+
+TEST(CheckDoesNotHaveSideEffectsWhenFailing)
+{
+    g_sideEffect = 0;
+    {
+        UnitTest::TestResults testResults;
+        ScopedCurrentTest scopedResults(testResults);
+        CHECK(!FunctionWithSideEffects());
+    }
+    CHECK_EQUAL(1, g_sideEffect);
+}
+
 TEST(CheckEqualSucceedsOnEqual)
 {
     bool failure = true;
@@ -106,13 +135,6 @@ TEST(CheckEqualFailureContainsCorrectDetails)
     CHECK_EQUAL("suiteName", reporter.lastFailedSuite);
     CHECK_EQUAL("filename", reporter.lastFailedFile);
     CHECK_EQUAL(line, reporter.lastFailedLine);
-}
-
-int g_sideEffect = 0;
-int FunctionWithSideEffects()
-{
-    ++g_sideEffect;
-    return 1;
 }
 
 TEST(CheckEqualDoesNotHaveSideEffectsWhenPassing)

--- a/tests/TestCheckMacros.cpp
+++ b/tests/TestCheckMacros.cpp
@@ -14,10 +14,10 @@ TEST(CheckSucceedsOnTrue)
         RecordingReporter reporter;
         UnitTest::TestResults testResults(&reporter);
 
-		ScopedCurrentTest scopedResults(testResults);
-		CHECK(true);
+        ScopedCurrentTest scopedResults(testResults);
+        CHECK(true);
 
-		failure = (testResults.GetFailureCount() > 0);
+        failure = (testResults.GetFailureCount() > 0);
     }
 
     CHECK(!failure);
@@ -29,7 +29,7 @@ TEST(CheckFailsOnFalse)
     {
         RecordingReporter reporter;
         UnitTest::TestResults testResults(&reporter);
-		ScopedCurrentTest scopedResults(testResults);
+        ScopedCurrentTest scopedResults(testResults);
         CHECK(false);
         failure = (testResults.GetFailureCount() > 0);
     }
@@ -42,7 +42,7 @@ TEST(FailureReportsCorrectTestName)
     RecordingReporter reporter;
     {
         UnitTest::TestResults testResults(&reporter);
-		ScopedCurrentTest scopedResults(testResults);
+        ScopedCurrentTest scopedResults(testResults);
         CHECK(false);
     }
 
@@ -54,7 +54,7 @@ TEST(CheckFailureIncludesCheckContents)
     RecordingReporter reporter;
     {
         UnitTest::TestResults testResults(&reporter);
-		ScopedCurrentTest scopedResults(testResults);
+        ScopedCurrentTest scopedResults(testResults);
         const bool yaddayadda = false;
         CHECK(yaddayadda);
     }
@@ -68,7 +68,7 @@ TEST(CheckEqualSucceedsOnEqual)
     {
         RecordingReporter reporter;
         UnitTest::TestResults testResults(&reporter);
-		ScopedCurrentTest scopedResults(testResults);
+        ScopedCurrentTest scopedResults(testResults);
         CHECK_EQUAL(1, 1);
         failure = (testResults.GetFailureCount() > 0);
     }
@@ -82,7 +82,7 @@ TEST(CheckEqualFailsOnNotEqual)
     {
         RecordingReporter reporter;
         UnitTest::TestResults testResults(&reporter);
-		ScopedCurrentTest scopedResults(testResults);
+        ScopedCurrentTest scopedResults(testResults);
         CHECK_EQUAL(1, 2);
         failure = (testResults.GetFailureCount() > 0);
     }
@@ -96,10 +96,10 @@ TEST(CheckEqualFailureContainsCorrectDetails)
     RecordingReporter reporter;
     {
         UnitTest::TestResults testResults(&reporter);
-		UnitTest::TestDetails const testDetails("testName", "suiteName", "filename", -1);
-		ScopedCurrentTest scopedResults(testResults, &testDetails);
+        UnitTest::TestDetails const testDetails("testName", "suiteName", "filename", -1);
+        ScopedCurrentTest scopedResults(testResults, &testDetails);
 
-		CHECK_EQUAL(1, 123);    line = __LINE__;
+        CHECK_EQUAL(1, 123);    line = __LINE__;
     }
 
     CHECK_EQUAL("testName", reporter.lastFailedTest);
@@ -120,7 +120,7 @@ TEST(CheckEqualDoesNotHaveSideEffectsWhenPassing)
     g_sideEffect = 0;
     {
         UnitTest::TestResults testResults;
-		ScopedCurrentTest scopedResults(testResults);
+        ScopedCurrentTest scopedResults(testResults);
         CHECK_EQUAL(1, FunctionWithSideEffects());
     }
     CHECK_EQUAL(1, g_sideEffect);
@@ -131,7 +131,7 @@ TEST(CheckEqualDoesNotHaveSideEffectsWhenFailing)
     g_sideEffect = 0;
     {
         UnitTest::TestResults testResults;
-		ScopedCurrentTest scopedResults(testResults);
+        ScopedCurrentTest scopedResults(testResults);
         CHECK_EQUAL(2, FunctionWithSideEffects());
     }
     CHECK_EQUAL(1, g_sideEffect);
@@ -144,7 +144,7 @@ TEST(CheckCloseSucceedsOnEqual)
     {
         RecordingReporter reporter;
         UnitTest::TestResults testResults(&reporter);
-		ScopedCurrentTest scopedResults(testResults);
+        ScopedCurrentTest scopedResults(testResults);
         CHECK_CLOSE (1.0f, 1.001f, 0.01f);
         failure = (testResults.GetFailureCount() > 0);
     }
@@ -158,7 +158,7 @@ TEST(CheckCloseFailsOnNotEqual)
     {
         RecordingReporter reporter;
         UnitTest::TestResults testResults(&reporter);
-		ScopedCurrentTest scopedResults(testResults);
+        ScopedCurrentTest scopedResults(testResults);
         CHECK_CLOSE (1.0f, 1.1f, 0.01f);
         failure = (testResults.GetFailureCount() > 0);
     }
@@ -172,10 +172,10 @@ TEST(CheckCloseFailureContainsCorrectDetails)
     RecordingReporter reporter;
     {
         UnitTest::TestResults testResults(&reporter);
-		UnitTest::TestDetails testDetails("test", "suite", "filename", -1);
-		ScopedCurrentTest scopedResults(testResults, &testDetails);
+        UnitTest::TestDetails testDetails("test", "suite", "filename", -1);
+        ScopedCurrentTest scopedResults(testResults, &testDetails);
 
-		CHECK_CLOSE (1.0f, 1.1f, 0.01f);    line = __LINE__;
+        CHECK_CLOSE (1.0f, 1.1f, 0.01f);    line = __LINE__;
     }
 
     CHECK_EQUAL("test", reporter.lastFailedTest);
@@ -189,7 +189,7 @@ TEST(CheckCloseDoesNotHaveSideEffectsWhenPassing)
     g_sideEffect = 0;
     {
         UnitTest::TestResults testResults;
-		ScopedCurrentTest scopedResults(testResults);
+        ScopedCurrentTest scopedResults(testResults);
         CHECK_CLOSE (1, FunctionWithSideEffects(), 0.1f);
     }
     CHECK_EQUAL(1, g_sideEffect);
@@ -200,7 +200,7 @@ TEST(CheckCloseDoesNotHaveSideEffectsWhenFailing)
     g_sideEffect = 0;
     {
         UnitTest::TestResults testResults;
-		ScopedCurrentTest scopedResults(testResults);
+        ScopedCurrentTest scopedResults(testResults);
         CHECK_CLOSE (2, FunctionWithSideEffects(), 0.1f);
     }
     CHECK_EQUAL(1, g_sideEffect);
@@ -212,7 +212,7 @@ TEST(CheckArrayCloseSucceedsOnEqual)
     {
         RecordingReporter reporter;
         UnitTest::TestResults testResults(&reporter);
-		ScopedCurrentTest scopedResults(testResults);
+        ScopedCurrentTest scopedResults(testResults);
         const float data[4] = { 0, 1, 2, 3 };
         CHECK_ARRAY_CLOSE (data, data, 4, 0.01f);
         failure = (testResults.GetFailureCount() > 0);
@@ -227,13 +227,13 @@ TEST(CheckArrayCloseFailsOnNotEqual)
     {
         RecordingReporter reporter;
         UnitTest::TestResults testResults(&reporter);
-		ScopedCurrentTest scopedResults(testResults);
+        ScopedCurrentTest scopedResults(testResults);
 
-		int const data1[4] = { 0, 1, 2, 3 };
+        int const data1[4] = { 0, 1, 2, 3 };
         int const data2[4] = { 0, 1, 3, 3 };
-		CHECK_ARRAY_CLOSE (data1, data2, 4, 0.01f);
+        CHECK_ARRAY_CLOSE (data1, data2, 4, 0.01f);
 
-		failure = (testResults.GetFailureCount() > 0);
+        failure = (testResults.GetFailureCount() > 0);
     }
 
     CHECK(failure);
@@ -244,9 +244,9 @@ TEST(CheckArrayCloseFailureIncludesCheckExpectedAndActual)
     RecordingReporter reporter;
     {
         UnitTest::TestResults testResults(&reporter);
-		ScopedCurrentTest scopedResults(testResults);
+        ScopedCurrentTest scopedResults(testResults);
 
-		int const data1[4] = { 0, 1, 2, 3 };
+        int const data1[4] = { 0, 1, 2, 3 };
         int const data2[4] = { 0, 1, 3, 3 };
         CHECK_ARRAY_CLOSE (data1, data2, 4, 0.01f);
     }
@@ -261,10 +261,10 @@ TEST(CheckArrayCloseFailureContainsCorrectDetails)
     RecordingReporter reporter;
     {
         UnitTest::TestResults testResults(&reporter);
-		UnitTest::TestDetails testDetails("arrayCloseTest", "arrayCloseSuite", "filename", -1);
-		ScopedCurrentTest scopedResults(testResults, &testDetails);
+        UnitTest::TestDetails testDetails("arrayCloseTest", "arrayCloseSuite", "filename", -1);
+        ScopedCurrentTest scopedResults(testResults, &testDetails);
 
-		int const data1[4] = { 0, 1, 2, 3 };
+        int const data1[4] = { 0, 1, 2, 3 };
         int const data2[4] = { 0, 1, 3, 3 };
         CHECK_ARRAY_CLOSE (data1, data2, 4, 0.01f);     line = __LINE__;
     }
@@ -280,9 +280,9 @@ TEST(CheckArrayCloseFailureIncludesTolerance)
     RecordingReporter reporter;
     {
         UnitTest::TestResults testResults(&reporter);
-		ScopedCurrentTest scopedResults(testResults);
+        ScopedCurrentTest scopedResults(testResults);
 
-		float const data1[4] = { 0, 1, 2, 3 };
+        float const data1[4] = { 0, 1, 2, 3 };
         float const data2[4] = { 0, 1, 3, 3 };
         CHECK_ARRAY_CLOSE (data1, data2, 4, 0.01f);
     }
@@ -296,12 +296,12 @@ TEST(CheckArrayEqualSuceedsOnEqual)
     {
         RecordingReporter reporter;
         UnitTest::TestResults testResults(&reporter);
-		ScopedCurrentTest scopedResults(testResults);
+        ScopedCurrentTest scopedResults(testResults);
 
-		const float data[4] = { 0, 1, 2, 3 };
+        const float data[4] = { 0, 1, 2, 3 };
         CHECK_ARRAY_EQUAL (data, data, 4);
 
-		failure = (testResults.GetFailureCount() > 0);
+        failure = (testResults.GetFailureCount() > 0);
     }
 
     CHECK(!failure);
@@ -313,13 +313,13 @@ TEST(CheckArrayEqualFailsOnNotEqual)
     {
         RecordingReporter reporter;
         UnitTest::TestResults testResults(&reporter);
-		ScopedCurrentTest scopedResults(testResults);
+        ScopedCurrentTest scopedResults(testResults);
 
-		int const data1[4] = { 0, 1, 2, 3 };
+        int const data1[4] = { 0, 1, 2, 3 };
         int const data2[4] = { 0, 1, 3, 3 };
         CHECK_ARRAY_EQUAL (data1, data2, 4);
 
-		failure = (testResults.GetFailureCount() > 0);
+        failure = (testResults.GetFailureCount() > 0);
     }
 
     CHECK(failure);
@@ -330,9 +330,9 @@ TEST(CheckArrayEqualFailureIncludesCheckExpectedAndActual)
     RecordingReporter reporter;
     {
         UnitTest::TestResults testResults(&reporter);
-		ScopedCurrentTest scopedResults(testResults);
+        ScopedCurrentTest scopedResults(testResults);
 
-		int const data1[4] = { 0, 1, 2, 3 };
+        int const data1[4] = { 0, 1, 2, 3 };
         int const data2[4] = { 0, 1, 3, 3 };
         CHECK_ARRAY_EQUAL (data1, data2, 4);
     }
@@ -347,9 +347,9 @@ TEST(CheckArrayEqualFailureContainsCorrectInfo)
     RecordingReporter reporter;
     {
         UnitTest::TestResults testResults(&reporter);
-		ScopedCurrentTest scopedResults(testResults);
+        ScopedCurrentTest scopedResults(testResults);
 
-		int const data1[4] = { 0, 1, 2, 3 };
+        int const data1[4] = { 0, 1, 2, 3 };
         int const data2[4] = { 0, 1, 3, 3 };
         CHECK_ARRAY_EQUAL (data1, data2, 4);     line = __LINE__;
     }
@@ -371,9 +371,9 @@ TEST(CheckArrayCloseDoesNotHaveSideEffectsWhenPassing)
     g_sideEffect = 0;
     {
         UnitTest::TestResults testResults;
-		ScopedCurrentTest scopedResults(testResults);
+        ScopedCurrentTest scopedResults(testResults);
 
-		const float data[] = { 0, 1, 2, 3 };
+        const float data[] = { 0, 1, 2, 3 };
         CHECK_ARRAY_CLOSE (data, FunctionWithSideEffects2(), 4, 0.01f);
     }
     CHECK_EQUAL(1, g_sideEffect);
@@ -384,13 +384,13 @@ TEST(CheckArrayCloseDoesNotHaveSideEffectsWhenFailing)
     g_sideEffect = 0;
     {
         UnitTest::TestResults testResults;
-		ScopedCurrentTest scopedResults(testResults);
+        ScopedCurrentTest scopedResults(testResults);
 
-		const float data[] = { 0, 1, 3, 3 };
+        const float data[] = { 0, 1, 3, 3 };
         CHECK_ARRAY_CLOSE (data, FunctionWithSideEffects2(), 4, 0.01f);
     }
 
-	CHECK_EQUAL(1, g_sideEffect);
+    CHECK_EQUAL(1, g_sideEffect);
 }
 
 TEST(CheckArray2DCloseSucceedsOnEqual)
@@ -399,12 +399,12 @@ TEST(CheckArray2DCloseSucceedsOnEqual)
     {
         RecordingReporter reporter;
         UnitTest::TestResults testResults(&reporter);
-		ScopedCurrentTest scopedResults(testResults);
+        ScopedCurrentTest scopedResults(testResults);
 
-		const float data[2][2] = { {0, 1}, {2, 3} };
+        const float data[2][2] = { {0, 1}, {2, 3} };
         CHECK_ARRAY2D_CLOSE (data, data, 2, 2, 0.01f);
 
-		failure = (testResults.GetFailureCount() > 0);
+        failure = (testResults.GetFailureCount() > 0);
     }
 
     CHECK(!failure);
@@ -416,13 +416,13 @@ TEST(CheckArray2DCloseFailsOnNotEqual)
     {
         RecordingReporter reporter;
         UnitTest::TestResults testResults(&reporter);
-		ScopedCurrentTest scopedResults(testResults);
+        ScopedCurrentTest scopedResults(testResults);
 
-		int const data1[2][2] = { {0, 1}, {2, 3} };
+        int const data1[2][2] = { {0, 1}, {2, 3} };
         int const data2[2][2] = { {0, 1}, {3, 3} };
         CHECK_ARRAY2D_CLOSE (data1, data2, 2, 2, 0.01f);
 
-		failure = (testResults.GetFailureCount() > 0);
+        failure = (testResults.GetFailureCount() > 0);
     }
 
     CHECK(failure);
@@ -433,12 +433,12 @@ TEST(CheckArray2DCloseFailureIncludesCheckExpectedAndActual)
     RecordingReporter reporter;
     {
         UnitTest::TestResults testResults(&reporter);
-		ScopedCurrentTest scopedResults(testResults);
+        ScopedCurrentTest scopedResults(testResults);
 
-		int const data1[2][2] = { {0, 1}, {2, 3} };
+        int const data1[2][2] = { {0, 1}, {2, 3} };
         int const data2[2][2] = { {0, 1}, {3, 3} };
 
-		CHECK_ARRAY2D_CLOSE (data1, data2, 2, 2, 0.01f);
+        CHECK_ARRAY2D_CLOSE (data1, data2, 2, 2, 0.01f);
     }
 
     CHECK(strstr(reporter.lastFailedMessage, "xpected [ [ 0 1 ] [ 2 3 ] ]"));
@@ -451,12 +451,12 @@ TEST(CheckArray2DCloseFailureContainsCorrectDetails)
     RecordingReporter reporter;
     {
         UnitTest::TestResults testResults(&reporter);
-		UnitTest::TestDetails testDetails("array2DCloseTest", "array2DCloseSuite", "filename", -1);
-		ScopedCurrentTest scopedResults(testResults, &testDetails);
+        UnitTest::TestDetails testDetails("array2DCloseTest", "array2DCloseSuite", "filename", -1);
+        ScopedCurrentTest scopedResults(testResults, &testDetails);
 
-		int const data1[2][2] = { {0, 1}, {2, 3} };
+        int const data1[2][2] = { {0, 1}, {2, 3} };
         int const data2[2][2] = { {0, 1}, {3, 3} };
-		CHECK_ARRAY2D_CLOSE (data1, data2, 2, 2, 0.01f);     line = __LINE__;
+        CHECK_ARRAY2D_CLOSE (data1, data2, 2, 2, 0.01f);     line = __LINE__;
     }
 
     CHECK_EQUAL("array2DCloseTest", reporter.lastFailedTest);
@@ -470,9 +470,9 @@ TEST(CheckArray2DCloseFailureIncludesTolerance)
     RecordingReporter reporter;
     {
         UnitTest::TestResults testResults(&reporter);
-		ScopedCurrentTest scopedResults(testResults);
+        ScopedCurrentTest scopedResults(testResults);
 
-		float const data1[2][2] = { {0, 1}, {2, 3} };
+        float const data1[2][2] = { {0, 1}, {2, 3} };
         float const data2[2][2] = { {0, 1}, {3, 3} };
         CHECK_ARRAY2D_CLOSE (data1, data2, 2, 2, 0.01f);
     }
@@ -494,9 +494,9 @@ TEST(CheckArray2DCloseDoesNotHaveSideEffectsWhenPassing)
     g_sideEffect = 0;
     {
         UnitTest::TestResults testResults;
-		ScopedCurrentTest scopedResults(testResults);
+        ScopedCurrentTest scopedResults(testResults);
 
-		const float data[2][2] = { {0, 1}, {2, 3} };
+        const float data[2][2] = { {0, 1}, {2, 3} };
         CHECK_ARRAY2D_CLOSE (data, FunctionWithSideEffects3(), 2, 2, 0.01f);
     }
     CHECK_EQUAL(1, g_sideEffect);
@@ -507,9 +507,9 @@ TEST(CheckArray2DCloseDoesNotHaveSideEffectsWhenFailing)
     g_sideEffect = 0;
     {
         UnitTest::TestResults testResults;
-		ScopedCurrentTest scopedResults(testResults);
+        ScopedCurrentTest scopedResults(testResults);
 
-		const float data[2][2] = { {0, 1}, {3, 3} };
+        const float data[2][2] = { {0, 1}, {3, 3} };
         CHECK_ARRAY2D_CLOSE (data, FunctionWithSideEffects3(), 2, 2, 0.01f);
     }
     CHECK_EQUAL(1, g_sideEffect);

--- a/tests/TestCheckMacros.cpp
+++ b/tests/TestCheckMacros.cpp
@@ -280,21 +280,23 @@ TEST(CheckArrayEqualFailureIncludesCheckExpectedAndActual)
     CHECK(strstr(reporter.lastFailedMessage, "was [ 0 1 3 3 ]"));
 }
 
-TEST(CheckArrayEqualFailureContainsCorrectInfo)
+TEST(CheckArrayEqualFailureContainsCorrectDetails)
 {
     int line = 0;
     RecordingReporter reporter;
     {
         UnitTest::TestResults testResults(&reporter);
-        ScopedCurrentTest scopedResults(testResults);
+        UnitTest::TestDetails testDetails("arrayEqualTest", "arrayEqualSuite", "filename", -1);
+        ScopedCurrentTest scopedResults(testResults, &testDetails);
 
         int const data1[4] = { 0, 1, 2, 3 };
         int const data2[4] = { 0, 1, 3, 3 };
         CHECK_ARRAY_EQUAL (data1, data2, 4);     line = __LINE__;
     }
 
-    CHECK_EQUAL("CheckArrayEqualFailureContainsCorrectInfo", reporter.lastFailedTest);
-    CHECK_EQUAL(__FILE__, reporter.lastFailedFile);
+    CHECK_EQUAL("arrayEqualTest", reporter.lastFailedTest);
+    CHECK_EQUAL("arrayEqualSuite", reporter.lastFailedSuite);
+    CHECK_EQUAL("filename", reporter.lastFailedFile);
     CHECK_EQUAL(line, reporter.lastFailedLine);
 }
 

--- a/tests/TestUnitTestPP.cpp
+++ b/tests/TestUnitTestPP.cpp
@@ -38,6 +38,13 @@ TEST(CheckEqualWorksWithPointers)
     CHECK_EQUAL((void*)0, p);
 }
 
+TEST(CanUseCheckEqualsDescribedToGetCustomFailureMessage)
+{
+    int const x = 0x44;
+    int const expected = 0x44;
+    CHECK_EQUAL_DESCRIBED(expected, x, "x is not " << std::showbase << std::hex << expected << ", x is " << x);
+}
+
 TEST(ValidCheckCloseSucceeds)
 {
     CHECK_CLOSE(2.0f, 2.001f, 0.01f);

--- a/tests/TestUnitTestPP.cpp
+++ b/tests/TestUnitTestPP.cpp
@@ -80,6 +80,13 @@ TEST(ArrayCloseSucceeds)
     CHECK_ARRAY_CLOSE(a1, a2, 3, 0.1f);
 }
 
+TEST(CanUseCheckArrayCloseDescribedToGetCustomFailureMessage)
+{
+    float const x[] = {1, 2.01f, 3};
+    float const expected[] = {1, 2, 3};
+    CHECK_ARRAY_CLOSE_DESCRIBED(expected, x, 3, 0.01f, "x is not correct, have you checked the flux capacitor?");
+}
+
 TEST(Array2dCloseSucceeds)
 {
     float const a1[][3] = {{1, 2, 3}, {4, 5, 6}};

--- a/tests/TestUnitTestPP.cpp
+++ b/tests/TestUnitTestPP.cpp
@@ -66,6 +66,13 @@ TEST(ArrayEqualSucceeds)
     CHECK_ARRAY_EQUAL(a1, a2, 3);
 }
 
+TEST(CanUseCheckArrayEqualDescribedToGetCustomFailureMessage)
+{
+    int const x[] = {1, 2, 3};
+    int const expected[] = {1, 2, 3};
+    CHECK_ARRAY_EQUAL_DESCRIBED(expected, x, 3, "x is not correct, have you checked the flux capacitor?");
+}
+
 TEST(ArrayCloseSucceeds)
 {
     float const a1[] = {1, 2, 3};

--- a/tests/TestUnitTestPP.cpp
+++ b/tests/TestUnitTestPP.cpp
@@ -94,6 +94,13 @@ TEST(Array2dCloseSucceeds)
     CHECK_ARRAY2D_CLOSE(a1, a2, 2, 3, 0.1f);
 }
 
+TEST(CanUseCheckArray2dCloseDescribedToGetCustomFailureMessage)
+{
+    float const x[][3] = {{1, 2.01f, 3}, {4, 5.01, 6}};
+    float const expected[][3] = {{1, 2, 3}, {4, 5, 6}};
+    CHECK_ARRAY2D_CLOSE_DESCRIBED(expected, x, 2, 3, 0.1f, "x is not correct, have you checked the flux capacitor?");
+}
+
 #ifndef UNITTEST_NO_EXCEPTIONS
 
 TEST(CheckThrowMacroSucceedsOnCorrectException)

--- a/tests/TestUnitTestPP.cpp
+++ b/tests/TestUnitTestPP.cpp
@@ -120,6 +120,11 @@ TEST(CheckAssertSucceeds)
     CHECK_ASSERT(UnitTest::ReportAssert("desc", "file", 0));
 }
 
+TEST(CanUseCheckAssertDescribedToGetCustomFailureMessage)
+{
+    CHECK_ASSERT_DESCRIBED(UnitTest::ReportAssert("desc", "file", 0), "This should really trigger an assert");
+}
+
 TEST(CheckThrowMacroFailsOnMissingException)
 {
     class NoThrowTest : public UnitTest::Test

--- a/tests/TestUnitTestPP.cpp
+++ b/tests/TestUnitTestPP.cpp
@@ -1,3 +1,4 @@
+#include <ios>
 #include "UnitTest++/UnitTestPP.h"
 #include "ScopedCurrentTest.h"
 
@@ -16,6 +17,12 @@ TEST(CheckWorksWithPointers)
     void* p = (void *)0x100;
     CHECK(p);
     CHECK(p != 0);
+}
+
+TEST(CanUseCheckDescribedToGetCustomFailureMessage)
+{
+    bool const b = true;
+    CHECK_DESCRIBED(b, "b is not " << std::boolalpha << true << ", b is " << b);
 }
 
 TEST(ValidCheckEqualSucceeds)

--- a/tests/TestUnitTestPP.cpp
+++ b/tests/TestUnitTestPP.cpp
@@ -109,6 +109,12 @@ TEST(CheckThrowMacroSucceedsOnCorrectException)
     CHECK_THROW(throw TestException(), TestException);
 }
 
+TEST(CanUseCheckThrowDescribedToGetCustomFailureMessage)
+{
+    struct TestException {};
+    CHECK_THROW_DESCRIBED(throw TestException(), TestException, "This should really throw a TestException");
+}
+
 TEST(CheckAssertSucceeds)
 {
     CHECK_ASSERT(UnitTest::ReportAssert("desc", "file", 0));

--- a/tests/TestUnitTestPP.cpp
+++ b/tests/TestUnitTestPP.cpp
@@ -1,4 +1,5 @@
 #include <ios>
+#include <iomanip>
 #include "UnitTest++/UnitTestPP.h"
 #include "ScopedCurrentTest.h"
 
@@ -49,6 +50,13 @@ TEST(ValidCheckCloseSucceeds)
 {
     CHECK_CLOSE(2.0f, 2.001f, 0.01f);
     CHECK_CLOSE(2.001f, 2.0f, 0.01f);
+}
+
+TEST(CanUseCheckCloseDescribedToGetCustomFailureMessage)
+{
+    float const x = 2.001f;
+    float const expected = 2.0f;
+    CHECK_CLOSE_DESCRIBED(expected, x, 0.01f, "x is not close to " << std::setprecision(5) << expected << ", x is " << x);
 }
 
 TEST(ArrayEqualSucceeds)

--- a/tests/TestUnitTestPP.cpp
+++ b/tests/TestUnitTestPP.cpp
@@ -90,7 +90,7 @@ TEST(CanUseCheckArrayCloseDescribedToGetCustomFailureMessage)
 TEST(Array2dCloseSucceeds)
 {
     float const a1[][3] = {{1, 2, 3}, {4, 5, 6}};
-    float const a2[][3] = {{1, 2.01f, 3}, {4, 5.01, 6}};
+    float const a2[][3] = {{1, 2.01f, 3}, {4, 5.01f, 6}};
     CHECK_ARRAY2D_CLOSE(a1, a2, 2, 3, 0.1f);
 }
 

--- a/tests/TestUnitTestPP.cpp
+++ b/tests/TestUnitTestPP.cpp
@@ -37,11 +37,25 @@ TEST(ValidCheckCloseSucceeds)
     CHECK_CLOSE(2.001f, 2.0f, 0.01f);
 }
 
+TEST(ArrayEqualSucceeds)
+{
+    int const a1[] = {1, 2, 3};
+    int const a2[] = {1, 2, 3};
+    CHECK_ARRAY_EQUAL(a1, a2, 3);
+}
+
 TEST(ArrayCloseSucceeds)
 {
     float const a1[] = {1, 2, 3};
     float const a2[] = {1, 2.01f, 3};
     CHECK_ARRAY_CLOSE(a1, a2, 3, 0.1f);
+}
+
+TEST(Array2dCloseSucceeds)
+{
+    float const a1[][3] = {{1, 2, 3}, {4, 5, 6}};
+    float const a2[][3] = {{1, 2.01f, 3}, {4, 5.01, 6}};
+    CHECK_ARRAY2D_CLOSE(a1, a2, 2, 3, 0.1f);
 }
 
 #ifndef UNITTEST_NO_EXCEPTIONS

--- a/tests/TestUnitTestPP.cpp
+++ b/tests/TestUnitTestPP.cpp
@@ -74,14 +74,14 @@ TEST(CheckThrowMacroFailsOnMissingException)
     };
 
     UnitTest::TestResults results;
-	{
-		ScopedCurrentTest scopedResults(results);
+    {
+        ScopedCurrentTest scopedResults(results);
 
-		NoThrowTest test;
-		test.Run();
-	}
+        NoThrowTest test;
+        test.Run();
+    }
 
-	CHECK_EQUAL(1, results.GetFailureCount());
+    CHECK_EQUAL(1, results.GetFailureCount());
 }
 
 TEST(CheckThrowMacroFailsOnWrongException)
@@ -97,14 +97,14 @@ TEST(CheckThrowMacroFailsOnWrongException)
     };
 
     UnitTest::TestResults results;
-	{
-		ScopedCurrentTest scopedResults(results);
+    {
+        ScopedCurrentTest scopedResults(results);
 
-		WrongThrowTest test;
-		test.Run();
-	}
+        WrongThrowTest test;
+        test.Run();
+    }
 
-	CHECK_EQUAL(1, results.GetFailureCount());
+    CHECK_EQUAL(1, results.GetFailureCount());
 }
 
 #endif
@@ -137,12 +137,12 @@ TEST_FIXTURE(SimpleFixture, OnlyOneFixtureAliveAtATime)
 
 void CheckBool(const bool b)
 {
-	CHECK(b);
+    CHECK(b);
 }
 
 TEST(CanCallCHECKOutsideOfTestFunction)
 {
-	CheckBool(true);
+    CheckBool(true);
 }
 
 }

--- a/tests/TestUnitTestPP.cpp
+++ b/tests/TestUnitTestPP.cpp
@@ -96,7 +96,7 @@ TEST(Array2dCloseSucceeds)
 
 TEST(CanUseCheckArray2dCloseDescribedToGetCustomFailureMessage)
 {
-    float const x[][3] = {{1, 2.01f, 3}, {4, 5.01, 6}};
+    float const x[][3] = {{1, 2.01f, 3}, {4, 5.01f, 6}};
     float const expected[][3] = {{1, 2, 3}, {4, 5, 6}};
     CHECK_ARRAY2D_CLOSE_DESCRIBED(expected, x, 2, 3, 0.1f, "x is not correct, have you checked the flux capacitor?");
 }


### PR DESCRIPTION
In some cases it is very helpful to be able to use a custom failure message when using UnitTest++ check macros. There are several usecases for this. One is when the default formatting of expected and actual is not optimal and the user wants to apply their own formatting to make failures easier to understand. Another example when looping over lots of test stimuli and expected results. In this case it is very beneficial to be able to print the iteration or test index to identify exactly what test instance failed rather than guessing base on line number and the values involved.

The chosen implementation is to add *_DESCRIBED versions of all CHECK_* macros (e.g CHECK_DESCRIBED. The described versions take one additional argument, the description. The description argument will be streamed to a UnitTest::MemoryOutStream object and which is then used as the failure description. This allows the user to use the standard io manipulators to customize the formatting (e.g `CHECK_DESCRIBED(b, "b is not " << std::boolalpha << true << ", b is " << b);`).