### PR TITLE
Disable tests in TestTestMacros.cpp which throw exceptions from destructors

### DIFF
--- a/tests/TestTestMacros.cpp
+++ b/tests/TestTestMacros.cpp
@@ -136,6 +136,11 @@ TEST(FixturesWithThrowingCtorsAreFailures)
 	CHECK(strstr(reporter.lastFailedMessage, "while constructing fixture"));
 }
 
+// Visual Studio 2015 in compliance with C++11 standard
+// implicitly adds a 'noexcept' to all user defined 
+// destructors. Any exceptions thrown from destructors
+// cause abort() to be called on the process.
+#if(_MSC_VER < 1900)
 struct FixtureDtorThrows
 {
 	~FixtureDtorThrows() { throw "exception"; }
@@ -161,6 +166,7 @@ TEST(FixturesWithThrowingDtorsAreFailures)
 	CHECK_EQUAL(1, failureCount);
 	CHECK(strstr(reporter.lastFailedMessage, "while destroying fixture"));
 }
+#endif 
 
 const int FailingLine = 123;
 


### PR DESCRIPTION
Disable tests in TestTestMacros.cpp which throw exceptions from user defined destructors.

In accordance with the C++11 standard, Visual Studio 2015 adds an implicit
'noexcept' to all user defined destructors. Any destructor throwing an
exception causes abort() to be called on the process.

This pull request fixes #76.