### PR TITLE
Vs2015 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,21 @@ project(UnitTest++)
 
 option(UTPP_USE_PLUS_SIGN "Set this to OFF is you with to use '-cpp' instead of '++' in lib/include paths" ON)
 
+if(MSVC14 OR MSVC12)
+    # has the support we need
+else()
+    include(CheckCXXCompilerFlag)
+    CHECK_CXX_COMPILER_FLAG("-std=c++14" COMPILER_SUPPORTS_CXX14)
+    CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
+    if(COMPILER_SUPPORTS_CXX14)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+    elseif(COMPILER_SUPPORTS_CXX11)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+    else()
+            message(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
+    endif()
+endif()
+
 # get the main sources
 file(GLOB headers_ RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} UnitTest++/*.h)
 file(GLOB sources_ RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} UnitTest++/*.cpp)

--- a/UnitTest++/TimeConstraint.cpp
+++ b/UnitTest++/TimeConstraint.cpp
@@ -6,8 +6,8 @@
 namespace UnitTest {
 
 
-TimeConstraint::TimeConstraint(int ms, TestDetails const& details)
-	: m_details(details)
+TimeConstraint::TimeConstraint(int ms, TestDetails const& details, int lineNumber)
+	: m_details(details, lineNumber)
     , m_maxMs(ms)
 {
     m_timer.Start();

--- a/UnitTest++/TimeConstraint.h
+++ b/UnitTest++/TimeConstraint.h
@@ -3,16 +3,16 @@
 
 #include "TimeHelpers.h"
 #include "HelperMacros.h"
+#include "TestDetails.h"
 
 namespace UnitTest {
 
 class TestResults;
-class TestDetails;
 
 class UNITTEST_LINKAGE TimeConstraint
 {
 public:
-    TimeConstraint(int ms, TestDetails const& details);
+    TimeConstraint(int ms, TestDetails const& details, int lineNumber);
     ~TimeConstraint();
 
 private:
@@ -20,12 +20,12 @@ private:
 	TimeConstraint(TimeConstraint const&);
 
 	Timer m_timer;
-    TestDetails const& m_details;
+	TestDetails const m_details;
 	int const m_maxMs;
 };
 
 #define UNITTEST_TIME_CONSTRAINT(ms) \
-	UnitTest::TimeConstraint unitTest__timeConstraint__(ms, UnitTest::TestDetails(m_details, __LINE__))
+	UnitTest::TimeConstraint unitTest__timeConstraint__(ms, m_details, __LINE__)
 
 #define UNITTEST_TIME_CONSTRAINT_EXEMPT() \
 	UNITTEST_MULTILINE_MACRO_BEGIN \

--- a/tests/TestTestMacros.cpp
+++ b/tests/TestTestMacros.cpp
@@ -10,6 +10,30 @@
 using namespace UnitTest;
 using namespace std;
 
+/* test for c++11 support */
+#ifndef _MSC_VER
+
+  /* Test for clang >= 3.3 */
+  #ifdef __clang__
+    #if (__clang__ == 1) && (__clang_major__ > 3 || (__clang_major__ == 3 && (__clang_minor__ > 2 )))
+      #define _NOEXCEPT_OP(x) noexcept(x)
+    #else
+        #define _NOEXCEPT_OP(x)
+    #endif
+  #endif
+
+  #ifndef __clang__
+    /* Test for GCC >= 4.8.0 */
+    #ifdef __GNUC__
+        #if (__GNUC__ > 4) || (__GNUC__ == 4 && (__GNUC_MINOR__ > 7 ))
+        #define _NOEXCEPT_OP(x) noexcept(x)
+        #else
+            #define _NOEXCEPT_OP(x)
+        #endif
+    #endif
+  #endif
+#endif
+
 namespace {
 
 TestList list1;
@@ -138,7 +162,7 @@ TEST(FixturesWithThrowingCtorsAreFailures)
 
 struct FixtureDtorThrows
 {
-	~FixtureDtorThrows() { throw "exception"; }
+	~FixtureDtorThrows() _NOEXCEPT_OP(false) { throw "exception"; }
 };
 
 TestList throwingFixtureTestList2;

--- a/tests/TestTimeConstraint.cpp
+++ b/tests/TestTimeConstraint.cpp
@@ -14,7 +14,7 @@ TEST(TimeConstraintSucceedsWithFastTest)
     TestResults result;
     {
 		ScopedCurrentTest scopedResult(result);
-        TimeConstraint t(200, TestDetails("", "", "", 0));
+        TimeConstraint t(200, TestDetails("", "", "", 0), 0);
         TimeHelpers::SleepMs(5);
     }
     CHECK_EQUAL(0, result.GetFailureCount());
@@ -25,7 +25,7 @@ TEST(TimeConstraintFailsWithSlowTest)
     TestResults result;
     {
 		ScopedCurrentTest scopedResult(result);
-        TimeConstraint t(10, TestDetails("", "", "", 0));
+        TimeConstraint t(10, TestDetails("", "", "", 0),0);
         TimeHelpers::SleepMs(20);
     }
     CHECK_EQUAL(1, result.GetFailureCount());
@@ -39,7 +39,7 @@ TEST(TimeConstraintFailureIncludesCorrectData)
 		ScopedCurrentTest scopedResult(result);
 
 		TestDetails const details("testname", "suitename", "filename", 10);
-        TimeConstraint t(10, details);
+        TimeConstraint t(10, details,10);
         TimeHelpers::SleepMs(20);
     }
 
@@ -56,7 +56,7 @@ TEST(TimeConstraintFailureIncludesTimeoutInformation)
     TestResults result(&reporter);
     {
 		ScopedCurrentTest scopedResult(result);
-        TimeConstraint t(10, TestDetails("", "", "", 0));
+        TimeConstraint t(10, TestDetails("", "", "", 0),0);
         TimeHelpers::SleepMs(20);
     }
 


### PR DESCRIPTION
Changes to support unittests in GSL library - addressing issue #79 
- Added checks for compilers supporting c++11.
- Defined  out the _NOEXCEPT  for compiler versions that do not support the noexcept keyword
- Worked around a dependency on non-portable behavior regarding the lifetimes of temporaries to ensure the line number gets added to the report of a failing test