### PR TITLE
adding an explicit cast for the conversion from int to useconds_t in …

### DIFF
--- a/UnitTest++/Posix/TimeHelpers.cpp
+++ b/UnitTest++/Posix/TimeHelpers.cpp
@@ -27,7 +27,7 @@ double Timer::GetTimeInMs() const
 
 void TimeHelpers::SleepMs(int ms)
 {
-    usleep(ms * 1000);
+    usleep(static_cast<useconds_t>(ms * 1000));
 }
 
 }


### PR DESCRIPTION
…TimeHelpers::SleepMS.

This is to address:

GSL/tests/unittest-cpp/UnitTest++/Posix/TimeHelpers.cpp:30:15: warning: implicit conversion changes
      signedness: 'int' to 'useconds_t' (aka 'unsigned int') [-Wsign-conversion]
    usleep(ms * 1000);
    ~~~~~~ ~~~^~~~~~
1 warning generated.