### PR TITLE
Reduce possible timing test failures

### DIFF
--- a/tests/TestTestRunner.cpp
+++ b/tests/TestTestRunner.cpp
@@ -110,8 +110,15 @@ namespace
         SlowTest test;
         list.Add(&test);
         
+        // Using UnitTest::Timer here is arguably a bit hokey and self-recursive, but
+        // it should guarantee that the test time recorded is less than that plus the 
+        // overhead of RunTestsIf -- the only thing we can reliably assert without
+        // reworking the test to not use sleeps at all
+        Timer actual;
+        actual.Start();
         RunTestsIf(list, NULL, True(), 0);
-        CHECK(reporter.lastFinishedTestTime >= 0.005f && reporter.lastFinishedTestTime <= 0.050f);
+
+        CHECK(reporter.lastFinishedTestTime >= 0.005f && reporter.lastFinishedTestTime <= actual.GetTimeInMs());
     }
     
     TEST_FIXTURE(TestRunnerFixture, FailureCountIsZeroWhenNoTestsAreRun)


### PR DESCRIPTION
TestFinishIsCalledWithCorrectTime was reliant on SleepMs(20) waking
up before a certain threshold was hit, which is not reliable. This
change uses the actual time of running tests as the top threshold;
not a great improvement but a good quick fix.

Fixes #90