### PR TITLE
Add support for CMake find_package()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,11 @@ else()
 	set (UTPP_INSTALL_DESTINATION "include/UnitTestPP")
 endif()
 
-install(TARGETS UnitTest++ DESTINATION lib)
+set(config_install_dir_ lib/cmake/${PROJECT_NAME})
+set(targets_export_name_ "${PROJECT_NAME}Targets")
+
+install(TARGETS UnitTest++ EXPORT "${targets_export_name_}" DESTINATION lib)
 install(FILES ${headers_} DESTINATION ${UTPP_INSTALL_DESTINATION})
 install(FILES ${platformHeaders_} DESTINATION ${UTPP_INSTALL_DESTINATION}/${platformDir_})
+install(FILES cmake/UnitTest++Config.cmake DESTINATION "${config_install_dir_}")
+install(EXPORT "${targets_export_name_}" DESTINATION "${config_install_dir_}")

--- a/cmake/UnitTest++Config.cmake
+++ b/cmake/UnitTest++Config.cmake
@@ -1,0 +1,2 @@
+include("${CMAKE_CURRENT_LIST_DIR}/UnitTest++Targets.cmake")
+get_filename_component(UTPP_INCLUDE_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../../include/" ABSOLUTE)


### PR DESCRIPTION
I had a need for this and noticed that it's also a current issue (#99).

The end result is you can import UnitTest++ in your CMakeLists.txt via:

    find_package(UnitTest++ REQUIRED NO_MODULE) # probably don't need NO_MODULE
    add_executable(foo ...)
    include_directories(${UTPP_INCLUDE_DIRS})
    target_link_libraries(foo UnitTest++)

More can be done with this including adding proper version checking support but i'm not sure how to go about that with a minimum CMake version of 2.8.1 since I don't have much experience with it. There's an easier method with more recent versions of CMake using CMakePackageConfigHelpers module and setting the version in the project() call.
A more recent version of CMake would also allow setting the install include directory as part of the imported target meaning you can drop include_directories(${UTPP_INCLUDE_DIRS}) calls when linking the target.

Worth noting that the config file doesn't deal with changing '++' to 'pp' but it looks like the CMakeLists.txt has sort of broken that functionality since it was originally put in and i'm not sure if I should approach that issue here.

