### PR TITLE
autoconf & automake improvements

### DIFF
--- a/UnitTest++/Makefile.am
+++ b/UnitTest++/Makefile.am
@@ -1,12 +1,13 @@
 lib_LTLIBRARIES = UnitTest++/libUnitTest++.la
-pkgincludedir = $(includedir)/UnitTest++/
+pkgincludedir = $(includedir)
+
 nobase_pkginclude_HEADERS = UnitTest++/AssertException.h UnitTest++/CheckMacros.h UnitTest++/Checks.h UnitTest++/CompositeTestReporter.h UnitTest++/Config.h UnitTest++/CurrentTest.h UnitTest++/DeferredTestReporter.h UnitTest++/DeferredTestResult.h UnitTest++/ExceptionMacros.h UnitTest++/ExecuteTest.h UnitTest++/HelperMacros.h UnitTest++/MemoryOutStream.h UnitTest++/ReportAssert.h UnitTest++/ReportAssertImpl.h UnitTest++/RequireMacros.h UnitTest++/RequiredCheckException.h UnitTest++/RequiredCheckTestReporter.h UnitTest++/Test.h UnitTest++/TestDetails.h UnitTest++/TestList.h UnitTest++/TestMacros.h UnitTest++/TestReporter.h UnitTest++/TestReporterStdout.h UnitTest++/TestResults.h UnitTest++/TestRunner.h UnitTest++/TestSuite.h UnitTest++/ThrowingTestReporter.h UnitTest++/TimeConstraint.h UnitTest++/TimeHelpers.h UnitTest++/UnitTest++.h UnitTest++/UnitTestPP.h UnitTest++/XmlTestReporter.h
 UnitTest___libUnitTest___la_SOURCES = UnitTest++/AssertException.cpp UnitTest++/Checks.cpp UnitTest++/CompositeTestReporter.cpp UnitTest++/CurrentTest.cpp UnitTest++/DeferredTestReporter.cpp UnitTest++/DeferredTestResult.cpp UnitTest++/MemoryOutStream.cpp UnitTest++/ReportAssert.cpp UnitTest++/RequiredCheckException.cpp UnitTest++/RequiredCheckTestReporter.cpp UnitTest++/Test.cpp UnitTest++/TestDetails.cpp UnitTest++/TestList.cpp UnitTest++/TestReporter.cpp UnitTest++/TestReporterStdout.cpp UnitTest++/TestResults.cpp UnitTest++/TestRunner.cpp UnitTest++/ThrowingTestReporter.cpp UnitTest++/TimeConstraint.cpp UnitTest++/XmlTestReporter.cpp
 
-if WINDOWS 
+if WINDOWS
 nobase_pkginclude_HEADERS += UnitTest++/Win32/TimeHelpers.h
 UnitTest___libUnitTest___la_SOURCES += UnitTest++/Win32/TimeHelpers.cpp
-else 
+else
 nobase_pkginclude_HEADERS += UnitTest++/Posix/SignalTranslator.h UnitTest++/Posix/TimeHelpers.h
 UnitTest___libUnitTest___la_SOURCES += UnitTest++/Posix/SignalTranslator.cpp UnitTest++/Posix/TimeHelpers.cpp
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -9,6 +9,7 @@ AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([UnitTest++.pc])
 
 AM_INIT_AUTOMAKE([foreign subdir-objects])
+AM_SILENT_RULES([yes])
 
 AC_CANONICAL_HOST
 

--- a/configure.ac
+++ b/configure.ac
@@ -12,8 +12,7 @@ AM_INIT_AUTOMAKE([foreign subdir-objects])
 
 AC_CANONICAL_HOST
 
-dnl Detect OS and set automake variables
-dnl Always the red-headed stepchild...
+dnl Detect Windows, as it doesn't implement UNIX signals and requires special code
 AM_CONDITIONAL([WINDOWS],
                [test "${host//mingw/}" != "${host}" -o "${host//msvc/}" != "${host}"])
 

--- a/configure.ac
+++ b/configure.ac
@@ -9,8 +9,14 @@ AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([UnitTest++.pc])
 
 AM_INIT_AUTOMAKE([foreign subdir-objects])
+
+AC_CANONICAL_HOST
+
+dnl Detect OS and set automake variables
+dnl Always the red-headed stepchild...
 AM_CONDITIONAL([WINDOWS],
-	  [test "${host#*mingw}" != "${host}" -o "${host#*msvc}" != "${host}"])
+               [test "${host//mingw/}" != "${host}" -o "${host//msvc/}" != "${host}"])
+
 LT_INIT()
 
 AC_SUBST([LIBUNITTEST_SO_VERSION], [1:6:0])


### PR DESCRIPTION
Hey there!

Sorry I haven't been around very much. I've been extremely busy with real life and my day job. 
I understand you were asking some questions about the autoconf / automake build scripts before the release earlier, but I haven't been able to get to any of my projects using unittest-cpp until now.  

However, I've currently switched my build environment from Cygwin to Mingw64+Msys2 and have noticed that the previous Windows $host detection checks in configure.ac were no longer working in the new environment.

I did some reading, and found the `AC_CANONICAL_HOST` autoconf directive, which uses `config.guess` to figure out the compiler's OS and architecture, and populates the $host variable for systems like msys2, which do not do so by default.

I also took the liberty of fixing issue #105, wherein `make install` installs unittest-cpp headers to `/usr/include/UnitTest++/UnitTest++/` (which was obviously not my intention; I just never install it system-wide and I guess I forgot to test it...)