### PR TITLE
Long and short macros

### DIFF
--- a/UnitTest++/CheckMacros.h
+++ b/UnitTest++/CheckMacros.h
@@ -138,7 +138,7 @@
    })                                                                                                                                                                                 \
    UNITTEST_MULTILINE_MACRO_END
 
-#if UNITTEST_ENABLE_SHORT_MACROS
+#ifndef UNITTEST_DISABLE_SHORT_MACROS
    #ifdef CHECK
       #error CHECK already defined, re-configure with UNITTEST_ENABLE_SHORT_MACROS set to 0 and use UNITTEST_CHECK instead
    #else
@@ -198,7 +198,7 @@
    UNITTEST_MULTILINE_MACRO_END
 #endif
 
-#if UNITTEST_ENABLE_SHORT_MACROS
+#ifndef UNITTEST_DISABLE_SHORT_MACROS
    #ifdef CHECK_THROW
       #error CHECK_THROW already defined, re-configure with UNITTEST_ENABLE_SHORT_MACROS set to 0 and use UNITTEST_CHECK_THROW instead
    #else

--- a/UnitTest++/CheckMacros.h
+++ b/UnitTest++/CheckMacros.h
@@ -13,20 +13,20 @@
 
 #define UNITTEST_CHECK(value)                                      \
    UNITTEST_MULTILINE_MACRO_BEGIN                                                                                                     \
-   UT_TRY                                                                                                                             \
+   UNITTEST_IMPL_TRY                                                                                                                             \
    ({                                                                                                                                 \
       if (!UnitTest::Check(value))                                                                                                    \
          UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), #value); \
    })                                                                                                                                 \
-   UT_RETHROW (UnitTest::RequiredCheckException)                                                                                                               \
-   UT_CATCH (std::exception, e,                                                                                                       \
+   UNITTEST_IMPL_RETHROW (UnitTest::RequiredCheckException)                                                                                                               \
+   UNITTEST_IMPL_CATCH (std::exception, e,                                                                                                       \
    {                                                                                                                                  \
       UnitTest::MemoryOutStream message;                                                                                              \
       message << "Unhandled exception (" << e.what() << ") in CHECK(" #value ")";                                                     \
       UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__),             \
                                                       message.GetText());                                                             \
    })                                                                                                                                 \
-   UT_CATCH_ALL                                                                                                                       \
+   UNITTEST_IMPL_CATCH_ALL                                                                                                                       \
       ({                                                                                                                              \
       UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__),             \
                                                       "Unhandled exception in CHECK(" #value ")");                                    \
@@ -35,19 +35,19 @@
 
 #define UNITTEST_CHECK_EQUAL(expected, actual)                                                                                                                \
    UNITTEST_MULTILINE_MACRO_BEGIN                                                                                                                    \
-   UT_TRY                                                                                                                                            \
+   UNITTEST_IMPL_TRY                                                                                                                                            \
    ({                                                                                                                                                \
       UnitTest::CheckEqual(*UnitTest::CurrentTest::Results(), expected, actual, UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__)); \
    })                                                                                                                                                \
-   UT_RETHROW (UnitTest::RequiredCheckException)                                                                                                               \
-   UT_CATCH (std::exception, e,                                                                                                                      \
+   UNITTEST_IMPL_RETHROW (UnitTest::RequiredCheckException)                                                                                                               \
+   UNITTEST_IMPL_CATCH (std::exception, e,                                                                                                                      \
    {                                                                                                                                                 \
       UnitTest::MemoryOutStream message;                                                                                                             \
       message << "Unhandled exception (" << e.what() << ") in CHECK_EQUAL(" #expected ", " #actual ")";                                              \
       UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__),                            \
                                                       message.GetText());                                                                            \
    })                                                                                                                                                \
-   UT_CATCH_ALL                                                                                                                                      \
+   UNITTEST_IMPL_CATCH_ALL                                                                                                                                      \
    ({                                                                                                                                                \
       UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__),                            \
                                                       "Unhandled exception in CHECK_EQUAL(" #expected ", " #actual ")");                             \
@@ -56,19 +56,19 @@
 
 #define UNITTEST_CHECK_CLOSE(expected, actual, tolerance)                                                                                                                \
    UNITTEST_MULTILINE_MACRO_BEGIN                                                                                                                               \
-   UT_TRY                                                                                                                                                       \
+   UNITTEST_IMPL_TRY                                                                                                                                                       \
    ({                                                                                                                                                           \
       UnitTest::CheckClose(*UnitTest::CurrentTest::Results(), expected, actual, tolerance, UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__)); \
    })                                                                                                                                                           \
-   UT_RETHROW (UnitTest::RequiredCheckException)                                                                                                               \
-   UT_CATCH (std::exception, e,                                                                                                                                 \
+   UNITTEST_IMPL_RETHROW (UnitTest::RequiredCheckException)                                                                                                               \
+   UNITTEST_IMPL_CATCH (std::exception, e,                                                                                                                                 \
    {                                                                                                                                                            \
       UnitTest::MemoryOutStream message;                                                                                                                        \
       message << "Unhandled exception (" << e.what() << ") in CHECK_CLOSE(" #expected ", " #actual ")";                                                         \
       UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__),                                       \
                                                       message.GetText());                                                                                       \
    })                                                                                                                                                           \
-   UT_CATCH_ALL                                                                                                                                                 \
+   UNITTEST_IMPL_CATCH_ALL                                                                                                                                                 \
    ({                                                                                                                                                           \
       UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__),                                       \
                                                       "Unhandled exception in CHECK_CLOSE(" #expected ", " #actual ")");                                        \
@@ -77,19 +77,19 @@
 
 #define UNITTEST_CHECK_ARRAY_EQUAL(expected, actual, count)                                                                                                               \
    UNITTEST_MULTILINE_MACRO_BEGIN                                                                                                                                \
-   UT_TRY                                                                                                                                                        \
+   UNITTEST_IMPL_TRY                                                                                                                                                        \
       ({                                                                                                                                                         \
       UnitTest::CheckArrayEqual(*UnitTest::CurrentTest::Results(), expected, actual, count, UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__)); \
    })                                                                                                                                                            \
-   UT_RETHROW (UnitTest::RequiredCheckException)                                                                                                               \
-   UT_CATCH (std::exception, e,                                                                                                                                  \
+   UNITTEST_IMPL_RETHROW (UnitTest::RequiredCheckException)                                                                                                               \
+   UNITTEST_IMPL_CATCH (std::exception, e,                                                                                                                                  \
    {                                                                                                                                                             \
       UnitTest::MemoryOutStream message;                                                                                                                         \
       message << "Unhandled exception (" << e.what() << ") in CHECK_ARRAY_EQUAL(" #expected ", " #actual ")";                                                    \
       UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__),                                        \
                                                       message.GetText());                                                                                        \
    })                                                                                                                                                            \
-   UT_CATCH_ALL                                                                                                                                                  \
+   UNITTEST_IMPL_CATCH_ALL                                                                                                                                                  \
       ({                                                                                                                                                         \
       UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__),                                        \
                                                       "Unhandled exception in CHECK_ARRAY_EQUAL(" #expected ", " #actual ")");                                   \
@@ -98,19 +98,19 @@
 
 #define UNITTEST_CHECK_ARRAY_CLOSE(expected, actual, count, tolerance)                                                                                                               \
    UNITTEST_MULTILINE_MACRO_BEGIN                                                                                                                                           \
-   UT_TRY                                                                                                                                                                   \
+   UNITTEST_IMPL_TRY                                                                                                                                                                   \
       ({                                                                                                                                                                    \
       UnitTest::CheckArrayClose(*UnitTest::CurrentTest::Results(), expected, actual, count, tolerance, UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__)); \
    })                                                                                                                                                                       \
-   UT_RETHROW (UnitTest::RequiredCheckException)                                                                                                               \
-   UT_CATCH (std::exception, e,                                                                                                                                             \
+   UNITTEST_IMPL_RETHROW (UnitTest::RequiredCheckException)                                                                                                               \
+   UNITTEST_IMPL_CATCH (std::exception, e,                                                                                                                                             \
    {                                                                                                                                                                        \
       UnitTest::MemoryOutStream message;                                                                                                                                    \
       message << "Unhandled exception (" << e.what() << ") in CHECK_ARRAY_CLOSE(" #expected ", " #actual ")";                                                               \
       UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__),                                                   \
                                                       message.GetText());                                                                                                   \
    })                                                                                                                                                                       \
-   UT_CATCH_ALL                                                                                                                                                             \
+   UNITTEST_IMPL_CATCH_ALL                                                                                                                                                             \
       ({                                                                                                                                                                    \
       UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__),                                                   \
                                                       "Unhandled exception in CHECK_ARRAY_CLOSE(" #expected ", " #actual ")");                                              \
@@ -119,19 +119,19 @@
 
 #define UNITTEST_CHECK_ARRAY2D_CLOSE(expected, actual, rows, columns, tolerance)                                                                                                               \
    UNITTEST_MULTILINE_MACRO_BEGIN                                                                                                                                                     \
-   UT_TRY                                                                                                                                                                             \
+   UNITTEST_IMPL_TRY                                                                                                                                                                             \
       ({                                                                                                                                                                              \
       UnitTest::CheckArray2DClose(*UnitTest::CurrentTest::Results(), expected, actual, rows, columns, tolerance, UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__)); \
    })                                                                                                                                                                                 \
-   UT_RETHROW (UnitTest::RequiredCheckException)                                                                                                               \
-   UT_CATCH (std::exception, e,                                                                                                                                                       \
+   UNITTEST_IMPL_RETHROW (UnitTest::RequiredCheckException)                                                                                                               \
+   UNITTEST_IMPL_CATCH (std::exception, e,                                                                                                                                                       \
    {                                                                                                                                                                                  \
       UnitTest::MemoryOutStream message;                                                                                                                                              \
       message << "Unhandled exception (" << e.what() << ") in CHECK_ARRAY2D_CLOSE(" #expected ", " #actual ")";                                                                       \
       UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__),                                                             \
                                                       message.GetText());                                                                                                             \
    })                                                                                                                                                                                 \
-   UT_CATCH_ALL                                                                                                                                                                       \
+   UNITTEST_IMPL_CATCH_ALL                                                                                                                                                                       \
       ({                                                                                                                                                                              \
       UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__),                                                             \
                                                       "Unhandled exception in CHECK_ARRAY2D_CLOSE(" #expected ", " #actual ")");                                                      \

--- a/UnitTest++/CheckMacros.h
+++ b/UnitTest++/CheckMacros.h
@@ -11,31 +11,7 @@
 #include "CurrentTest.h"
 #include "ReportAssertImpl.h"
 
-#ifdef CHECK
-   #error UnitTest++ redefines CHECK
-#endif
-
-#ifdef CHECK_EQUAL
-   #error UnitTest++ redefines CHECK_EQUAL
-#endif
-
-#ifdef CHECK_CLOSE
-   #error UnitTest++ redefines CHECK_CLOSE
-#endif
-
-#ifdef CHECK_ARRAY_EQUAL
-   #error UnitTest++ redefines CHECK_ARRAY_EQUAL
-#endif
-
-#ifdef CHECK_ARRAY_CLOSE
-   #error UnitTest++ redefines CHECK_ARRAY_CLOSE
-#endif
-
-#ifdef CHECK_ARRAY2D_CLOSE
-   #error UnitTest++ redefines CHECK_ARRAY2D_CLOSE
-#endif
-
-#define CHECK(value)                                                                                                                  \
+#define UNITTEST_CHECK(value)                                      \
    UNITTEST_MULTILINE_MACRO_BEGIN                                                                                                     \
    UT_TRY                                                                                                                             \
    ({                                                                                                                                 \
@@ -57,7 +33,7 @@
    })                                                                                                                                 \
    UNITTEST_MULTILINE_MACRO_END
 
-#define CHECK_EQUAL(expected, actual)                                                                                                                \
+#define UNITTEST_CHECK_EQUAL(expected, actual)                                                                                                                \
    UNITTEST_MULTILINE_MACRO_BEGIN                                                                                                                    \
    UT_TRY                                                                                                                                            \
    ({                                                                                                                                                \
@@ -78,7 +54,7 @@
    })                                                                                                                                                \
    UNITTEST_MULTILINE_MACRO_END
 
-#define CHECK_CLOSE(expected, actual, tolerance)                                                                                                                \
+#define UNITTEST_CHECK_CLOSE(expected, actual, tolerance)                                                                                                                \
    UNITTEST_MULTILINE_MACRO_BEGIN                                                                                                                               \
    UT_TRY                                                                                                                                                       \
    ({                                                                                                                                                           \
@@ -99,7 +75,7 @@
    })                                                                                                                                                           \
    UNITTEST_MULTILINE_MACRO_END
 
-#define CHECK_ARRAY_EQUAL(expected, actual, count)                                                                                                               \
+#define UNITTEST_CHECK_ARRAY_EQUAL(expected, actual, count)                                                                                                               \
    UNITTEST_MULTILINE_MACRO_BEGIN                                                                                                                                \
    UT_TRY                                                                                                                                                        \
       ({                                                                                                                                                         \
@@ -120,7 +96,7 @@
    })                                                                                                                                                            \
    UNITTEST_MULTILINE_MACRO_END
 
-#define CHECK_ARRAY_CLOSE(expected, actual, count, tolerance)                                                                                                               \
+#define UNITTEST_CHECK_ARRAY_CLOSE(expected, actual, count, tolerance)                                                                                                               \
    UNITTEST_MULTILINE_MACRO_BEGIN                                                                                                                                           \
    UT_TRY                                                                                                                                                                   \
       ({                                                                                                                                                                    \
@@ -141,7 +117,7 @@
    })                                                                                                                                                                       \
    UNITTEST_MULTILINE_MACRO_END
 
-#define CHECK_ARRAY2D_CLOSE(expected, actual, rows, columns, tolerance)                                                                                                               \
+#define UNITTEST_CHECK_ARRAY2D_CLOSE(expected, actual, rows, columns, tolerance)                                                                                                               \
    UNITTEST_MULTILINE_MACRO_BEGIN                                                                                                                                                     \
    UT_TRY                                                                                                                                                                             \
       ({                                                                                                                                                                              \
@@ -162,11 +138,48 @@
    })                                                                                                                                                                                 \
    UNITTEST_MULTILINE_MACRO_END
 
+#if UNITTEST_ENABLE_SHORT_MACROS
+   #ifdef CHECK
+      #error CHECK already defined, re-configure with UNITTEST_ENABLE_SHORT_MACROS set to 0 and use UNITTEST_CHECK instead
+   #else
+      #define CHECK UNITTEST_CHECK
+   #endif
+
+   #ifdef CHECK_EQUAL
+      #error CHECK_EQUAL already defined, re-configure with UNITTEST_ENABLE_SHORT_MACROS set to 0 and use UNITTEST_CHECK_EQUAL instead
+   #else
+      #define CHECK_EQUAL UNITTEST_CHECK_EQUAL
+   #endif
+
+   #ifdef CHECK_CLOSE
+      #error CHECK_CLOSE already defined, re-configure with UNITTEST_ENABLE_SHORT_MACROS set to 0 and use UNITTEST_CHECK_CLOSE instead
+   #else
+      #define CHECK_CLOSE UNITTEST_CHECK_CLOSE
+   #endif
+
+   #ifdef CHECK_ARRAY_EQUAL
+      #error CHECK_ARRAY_EQUAL already defined, re-configure with UNITTEST_ENABLE_SHORT_MACROS set to 0 and use UNITTEST_CHECK_ARRAY_EQUAL instead
+   #else
+      #define CHECK_ARRAY_EQUAL UNITTEST_CHECK_ARRAY_EQUAL
+   #endif
+
+   #ifdef CHECK_ARRAY_CLOSE
+      #error CHECK_ARRAY_CLOSE already defined, re-configure with UNITTEST_ENABLE_SHORT_MACROS set to 0 and use UNITTEST_CHECK_ARRAY_CLOSE instead
+   #else
+      #define CHECK_ARRAY_CLOSE UNITTEST_CHECK_ARRAY_CLOSE
+   #endif
+
+   #ifdef CHECK_ARRAY2D_CLOSE
+      #error CHECK_ARRAY2D_CLOSE already defined, re-configure with UNITTEST_ENABLE_SHORT_MACROS set to 0 and use UNITTEST_CHECK_ARRAY2D_CLOSE instead
+   #else
+      #define CHECK_ARRAY2D_CLOSE UNITTEST_CHECK_ARRAY2D_CLOSE
+   #endif
+#endif
 
 // CHECK_THROW and CHECK_ASSERT only exist when UNITTEST_NO_EXCEPTIONS isn't defined (see config.h)
 #ifndef UNITTEST_NO_EXCEPTIONS
 
-#define CHECK_THROW(expression, ExpectedExceptionType)                                                                                                                                      \
+#define UNITTEST_CHECK_THROW(expression, ExpectedExceptionType)                                                                                                                                      \
    UNITTEST_MULTILINE_MACRO_BEGIN                                                                                                                                                           \
    bool caught_ = false;                                                                                                                                                                    \
    try { expression; }                                                                                                                                                                      \
@@ -177,7 +190,7 @@
    UNITTEST_MULTILINE_MACRO_END
 
 
-#define CHECK_ASSERT(expression)                       \
+#define UNITTEST_CHECK_ASSERT(expression)                       \
    UNITTEST_MULTILINE_MACRO_BEGIN                      \
    UnitTest::Detail::ExpectAssert(true);               \
    CHECK_THROW(expression, UnitTest::AssertException); \
@@ -185,4 +198,19 @@
    UNITTEST_MULTILINE_MACRO_END
 #endif
 
+#if UNITTEST_ENABLE_SHORT_MACROS
+   #ifdef CHECK_THROW
+      #error CHECK_THROW already defined, re-configure with UNITTEST_ENABLE_SHORT_MACROS set to 0 and use UNITTEST_CHECK_THROW instead
+   #else
+      #define CHECK_THROW UNITTEST_CHECK_THROW
+   #endif
+
+   #ifdef CHECK_ASSERT
+      #error CHECK_ASSERT already defined, re-configure with UNITTEST_ENABLE_SHORT_MACROS set to 0 and use UNITTEST_CHECK_ASSERT instead
+   #else
+      #define CHECK_ASSERT UNITTEST_CHECK_ASSERT
+   #endif
 #endif
+
+#endif
+

--- a/UnitTest++/Config.h
+++ b/UnitTest++/Config.h
@@ -72,9 +72,12 @@
 #endif
 
 // By default, UnitTest++ will attempt to define "short" macro names like CHECK and  CHECK_EQUAL
-// for "public" interface macros etc. Setting UNITTEST_ENABLE_SHORT_MACROS to 0 will disable
-// this behavior, leaving only the longer macros "namespaced" with the UNITTEST_ prefix.
+// for "public" interface macros etc. Defining UNITTEST_DISABLE_SHORT_MACROS in your project
+// will disable this behavior, leaving only the longer macros "namespaced" with the UNITTEST_
+// prefix.
+//
 // "Internal" utility macros will only have the UNITTEST_IMPL_ prefix.
-#define UNITTEST_ENABLE_SHORT_MACROS 1
+
+// #define UNITTEST_DISABLE_SHORT_MACROS
 
 #endif

--- a/UnitTest++/Config.h
+++ b/UnitTest++/Config.h
@@ -16,7 +16,7 @@
    #ifdef _USRDLL
       #define UNITTEST_WIN32_DLL
    #endif
- 
+
    #define UNITTEST_WIN32
 #endif
 
@@ -70,5 +70,11 @@
 #else
    #define UNIITEST_NS_QUAL_STD(x) ::std::x
 #endif
+
+// By default, UnitTest++ will attempt to define "short" macro names like CHECK, CHECK_EQUAL,
+// etc. Setting UNITTEST_ENABLE_SHORT_MACROS to 0 will disable this behavior, leaving
+// only the longer macros "namespaced" with the UNITTEST_ prefix.
+
+#define UNITTEST_ENABLE_SHORT_MACROS 1
 
 #endif

--- a/UnitTest++/Config.h
+++ b/UnitTest++/Config.h
@@ -71,10 +71,10 @@
    #define UNIITEST_NS_QUAL_STD(x) ::std::x
 #endif
 
-// By default, UnitTest++ will attempt to define "short" macro names like CHECK, CHECK_EQUAL,
-// etc. Setting UNITTEST_ENABLE_SHORT_MACROS to 0 will disable this behavior, leaving
-// only the longer macros "namespaced" with the UNITTEST_ prefix.
-
+// By default, UnitTest++ will attempt to define "short" macro names like CHECK and  CHECK_EQUAL
+// for "public" interface macros etc. Setting UNITTEST_ENABLE_SHORT_MACROS to 0 will disable
+// this behavior, leaving only the longer macros "namespaced" with the UNITTEST_ prefix.
+// "Internal" utility macros will only have the UNITTEST_IMPL_ prefix.
 #define UNITTEST_ENABLE_SHORT_MACROS 1
 
 #endif

--- a/UnitTest++/ExceptionMacros.h
+++ b/UnitTest++/ExceptionMacros.h
@@ -4,17 +4,17 @@
 #include "Config.h"
 
 #ifndef UNITTEST_NO_EXCEPTIONS
-   #define UT_TRY(x) try x
-   #define UT_THROW(x) throw x
-   #define UT_RETHROW(ExceptionType) catch(ExceptionType&) { throw; }
-   #define UT_CATCH(ExceptionType, ExceptionName, CatchBody) catch(ExceptionType& ExceptionName) CatchBody
-   #define UT_CATCH_ALL(CatchBody) catch(...) CatchBody
+   #define UNITTEST_IMPL_TRY(x) try x
+   #define UNITTEST_IMPL_THROW(x) throw x
+   #define UNITTEST_IMPL_RETHROW(ExceptionType) catch(ExceptionType&) { throw; }
+   #define UNITTEST_IMPL_CATCH(ExceptionType, ExceptionName, CatchBody) catch(ExceptionType& ExceptionName) CatchBody
+   #define UNITTEST_IMPL_CATCH_ALL(CatchBody) catch(...) CatchBody
 #else
-   #define UT_TRY(x) x
-   #define UT_THROW(x)
-   #define UT_RETHROW(ExceptionType)
-   #define UT_CATCH(ExceptionType, ExceptionName, CatchBody)
-   #define UT_CATCH_ALL(CatchBody)
+   #define UNITTEST_IMPL_TRY(x) x
+   #define UNITTEST_IMPL_THROW(x)
+   #define UNITTEST_IMPL_RETHROW(ExceptionType)
+   #define UNITTEST_IMPL_CATCH(ExceptionType, ExceptionName, CatchBody)
+   #define UNITTEST_IMPL_CATCH_ALL(CatchBody)
 #endif
 
 #endif

--- a/UnitTest++/ExecuteTest.h
+++ b/UnitTest++/ExecuteTest.h
@@ -31,23 +31,23 @@ namespace UnitTest {
       {
 #endif
 #ifndef UNITTEST_POSIX
-      UT_TRY({ testObject.RunImpl(); })
+      UNITTEST_IMPL_TRY({ testObject.RunImpl(); })
 #else
-      UT_TRY
+      UNITTEST_IMPL_TRY
          ({
          UNITTEST_THROW_SIGNALS_POSIX_ONLY
          testObject.RunImpl();
       })
 #endif
-      UT_CATCH(RequiredCheckException, e, { (void)e; })
-      UT_CATCH(AssertException, e, { (void)e; })
-      UT_CATCH(std::exception, e,
+      UNITTEST_IMPL_CATCH(RequiredCheckException, e, { (void)e; })
+      UNITTEST_IMPL_CATCH(AssertException, e, { (void)e; })
+      UNITTEST_IMPL_CATCH(std::exception, e,
       {
          MemoryOutStream stream;
          stream << "Unhandled exception: " << e.what();
          CurrentTest::Results()->OnTestFailure(details, stream.GetText());
       })
-      UT_CATCH_ALL
+      UNITTEST_IMPL_CATCH_ALL
          ({
          CurrentTest::Results()->OnTestFailure(details, "Unhandled exception: test crashed");
       })

--- a/UnitTest++/RequireMacros.h
+++ b/UnitTest++/RequireMacros.h
@@ -3,10 +3,14 @@
 
 #include "RequiredCheckTestReporter.h"
 
-#ifdef REQUIRE
-    #error UnitTest++ redefines REQUIRE
-#endif
+#define UNITTEST_REQUIRE for(UnitTest::RequiredCheckTestReporter decoratedReporter(*UnitTest::CurrentTest::Results()); decoratedReporter.Next(); )
 
-#define REQUIRE for(UnitTest::RequiredCheckTestReporter decoratedReporter(*UnitTest::CurrentTest::Results()); decoratedReporter.Next(); )
+#if UNITTEST_ENABLE_SHORT_MACROS
+   #ifdef REQUIRE
+      #error REQUIRE already defined, re-configure with UNITTEST_ENABLE_SHORT_MACROS set to 0 and use UNITTEST_REQUIRE instead
+   #else
+      #define REQUIRE UNITTEST_REQUIRE
+   #endif
+#endif
 
 #endif

--- a/UnitTest++/RequireMacros.h
+++ b/UnitTest++/RequireMacros.h
@@ -5,7 +5,7 @@
 
 #define UNITTEST_REQUIRE for(UnitTest::RequiredCheckTestReporter decoratedReporter(*UnitTest::CurrentTest::Results()); decoratedReporter.Next(); )
 
-#if UNITTEST_ENABLE_SHORT_MACROS
+#ifndef UNITTEST_DISABLE_SHORT_MACROS
    #ifdef REQUIRE
       #error REQUIRE already defined, re-configure with UNITTEST_ENABLE_SHORT_MACROS set to 0 and use UNITTEST_REQUIRE instead
    #else

--- a/UnitTest++/TestMacros.h
+++ b/UnitTest++/TestMacros.h
@@ -101,7 +101,7 @@
 
 #define UNITTEST_TEST_FIXTURE(Fixture,Name) UNITTEST_IMPL_TEST_FIXTURE(Fixture, Name, UnitTest::Test::GetTestList())
 
-#if UNITTEST_ENABLE_SHORT_MACROS
+#ifndef UNITTEST_DISABLE_SHORT_MACROS
    #ifdef SUITE
       #error SUITE already defined, re-configure with UNITTEST_ENABLE_SHORT_MACROS set to 0 and use UNITTEST_SUITE instead
    #else

--- a/UnitTest++/TestMacros.h
+++ b/UnitTest++/TestMacros.h
@@ -15,19 +15,7 @@
 #include "Posix/SignalTranslator.h"
 #endif
 
-#ifdef TEST
-#error UnitTest++ redefines TEST
-#endif
-
-#ifdef TEST_EX
-#error UnitTest++ redefines TEST_EX
-#endif
-
-#ifdef TEST_FIXTURE_EX
-#error UnitTest++ redefines TEST_FIXTURE_EX
-#endif
-
-#define SUITE(Name)                           \
+#define UNITTEST_SUITE(Name)                  \
    namespace Suite ## Name {                  \
       namespace UnitTestSuite {               \
          inline char const* GetSuiteName () { \
@@ -37,7 +25,7 @@
    }                                          \
    namespace Suite ## Name
 
-#define TEST_EX(Name, List)                                                              \
+#define UNITTEST_IMPL_TEST(Name, List)                                                              \
    class Test ## Name : public UnitTest::Test                                            \
    {                                                                                     \
    public:                                                                               \
@@ -51,10 +39,10 @@
    void Test ## Name::RunImpl() const
 
 
-#define TEST(Name) TEST_EX(Name, UnitTest::Test::GetTestList())
+#define UNITTEST_TEST(Name) UNITTEST_IMPL_TEST(Name, UnitTest::Test::GetTestList())
 
 
-#define TEST_FIXTURE_EX(Fixture, Name, List)                                                                             \
+#define UNITTEST_IMPL_TEST_FIXTURE(Fixture, Name, List)                                                                             \
    class Fixture ## Name ## Helper : public Fixture                                                                      \
    {                                                                                                                     \
    public:                                                                                                               \
@@ -111,7 +99,26 @@
    }                                                                                                                     \
    void Fixture ## Name ## Helper::RunImpl()
 
-#define TEST_FIXTURE(Fixture,Name) TEST_FIXTURE_EX(Fixture, Name, UnitTest::Test::GetTestList())
+#define UNITTEST_TEST_FIXTURE(Fixture,Name) UNITTEST_IMPL_TEST_FIXTURE(Fixture, Name, UnitTest::Test::GetTestList())
 
+#if UNITTEST_ENABLE_SHORT_MACROS
+   #ifdef SUITE
+      #error SUITE already defined, re-configure with UNITTEST_ENABLE_SHORT_MACROS set to 0 and use UNITTEST_SUITE instead
+   #else
+      #define SUITE UNITTEST_SUITE
+   #endif
+
+   #ifdef TEST
+      #error TEST already defined, re-configure with UNITTEST_ENABLE_SHORT_MACROS set to 0 and use UNITTEST_TEST instead
+   #else
+      #define TEST UNITTEST_TEST
+   #endif
+
+   #ifdef TEST_FIXTURE
+      #error TEST_FIXTURE already defined, re-configure with UNITTEST_ENABLE_SHORT_MACROS set to 0 and use UNITTEST_TEST_FIXTURE instead
+   #else
+      #define TEST_FIXTURE UNITTEST_TEST_FIXTURE
+   #endif
+#endif
 
 #endif

--- a/UnitTest++/TestMacros.h
+++ b/UnitTest++/TestMacros.h
@@ -79,23 +79,23 @@
    void Test ## Fixture ## Name::RunImpl() const                                                                         \
    {                                                                                                                     \
       volatile bool ctorOk = false;                                                                                      \
-      UT_TRY                                                                                                             \
+      UNITTEST_IMPL_TRY                                                                                                             \
          ({                                                                                                              \
          Fixture ## Name ## Helper fixtureHelper(m_details);                                                             \
          ctorOk = true;                                                                                                  \
          UnitTest::ExecuteTest(fixtureHelper, m_details, false);                                                         \
       })                                                                                                                 \
-      UT_CATCH (UnitTest::AssertException, e,                                                                            \
+      UNITTEST_IMPL_CATCH (UnitTest::AssertException, e,                                                                            \
       {                                                                                                                  \
          (void)e;                                                                                                        \
       })                                                                                                                 \
-      UT_CATCH (std::exception, e,                                                                                       \
+      UNITTEST_IMPL_CATCH (std::exception, e,                                                                                       \
       {                                                                                                                  \
          UnitTest::MemoryOutStream stream;                                                                               \
          stream << "Unhandled exception: " << e.what();                                                                  \
          UnitTest::CurrentTest::Results()->OnTestFailure(m_details, stream.GetText());                                   \
       })                                                                                                                 \
-      UT_CATCH_ALL                                                                                                       \
+      UNITTEST_IMPL_CATCH_ALL                                                                                                       \
          ({                                                                                                              \
          if (ctorOk)                                                                                                     \
          {                                                                                                               \

--- a/tests/TestLongMacros.cpp
+++ b/tests/TestLongMacros.cpp
@@ -1,0 +1,45 @@
+#define UNITTEST_DISABLE_SHORT_MACROS
+
+#include "UnitTest++/UnitTestPP.h"
+
+// This file is not intended to test every little thing, just a few basics to hopefully ensure
+// the macros are working and the short macros are not defined.
+UNITTEST_SUITE(LongMacros)
+{
+   UNITTEST_TEST(LongCheckMacroWorks)
+   {
+      UNITTEST_CHECK(true);
+   }
+
+   class Fixture
+   {
+   public:
+      Fixture() : sanity_(true) {}
+   protected:
+      bool sanity_;
+   };
+
+   UNITTEST_TEST_FIXTURE(Fixture, LongFixtureMacroWorks)
+   {
+      UNITTEST_REQUIRE UNITTEST_CHECK(sanity_);
+   }
+
+   UNITTEST_TEST(ShortMacrosAreNotDefined)
+   {
+#if defined(CHECK) || \
+    defined(CHECK_EQUAL) || \
+    defined(CHECK_CLOSE) || \
+    defined(CHECK_ARRAY_EQUAL) || \
+    defined(CHECK_ARRAY_CLOSE) || \
+    defined(CHECK_ARRAY2D_CLOSE) || \
+    defined(CHECK_THROW) || \
+    defined(CHECK_ASSERT) || \
+    defined(SUITE) || \
+    defined(TEST) || \
+    defined(TEST_FIXTURE) || \
+    defined(REQUIRE)
+
+      UNITTEST_CHECK(false);
+#endif
+   }
+}

--- a/tests/TestTestMacros.cpp
+++ b/tests/TestTestMacros.cpp
@@ -46,7 +46,7 @@ using namespace std;
 namespace {
 
    TestList list1;
-   TEST_EX(DummyTest, list1)
+   UNITTEST_IMPL_TEST(DummyTest, list1)
    {}
 
    TEST (TestsAreAddedToTheListThroughMacro)
@@ -69,7 +69,7 @@ namespace {
    };
 
    TestList list2;
-   TEST_FIXTURE_EX(ThrowingThingie, DummyTestName, list2)
+   UNITTEST_IMPL_TEST_FIXTURE(ThrowingThingie, DummyTestName, list2)
    {}
 
    TEST (ExceptionsInFixtureAreReportedAsHappeningInTheFixture)
@@ -113,7 +113,7 @@ namespace {
    }
 
    TestList macroTestList1;
-   TEST_EX(MacroTestHelper1, macroTestList1)
+   UNITTEST_IMPL_TEST(MacroTestHelper1, macroTestList1)
    {}
 
    TEST(TestAddedWithTEST_EXMacroGetsDefaultSuite)
@@ -124,7 +124,7 @@ namespace {
    }
 
    TestList macroTestList2;
-   TEST_FIXTURE_EX(DummyFixture, MacroTestHelper2, macroTestList2)
+   UNITTEST_IMPL_TEST_FIXTURE(DummyFixture, MacroTestHelper2, macroTestList2)
    {}
 
    TEST(TestAddedWithTEST_FIXTURE_EXMacroGetsDefaultSuite)
@@ -144,7 +144,7 @@ namespace {
    };
 
    TestList throwingFixtureTestList1;
-   TEST_FIXTURE_EX(FixtureCtorThrows, FixtureCtorThrowsTestName, throwingFixtureTestList1)
+   UNITTEST_IMPL_TEST_FIXTURE(FixtureCtorThrows, FixtureCtorThrowsTestName, throwingFixtureTestList1)
    {}
 
    TEST(FixturesWithThrowingCtorsAreFailures)
@@ -170,7 +170,7 @@ namespace {
    };
 
    TestList throwingFixtureTestList2;
-   TEST_FIXTURE_EX(FixtureDtorThrows, FixtureDtorThrowsTestName, throwingFixtureTestList2)
+   UNITTEST_IMPL_TEST_FIXTURE(FixtureDtorThrows, FixtureDtorThrowsTestName, throwingFixtureTestList2)
    {}
 
    TEST(FixturesWithThrowingDtorsAreFailures)
@@ -200,7 +200,7 @@ namespace {
    };
 
    TestList ctorAssertFixtureTestList;
-   TEST_FIXTURE_EX(FixtureCtorAsserts, CorrectlyReportsAssertFailureInCtor, ctorAssertFixtureTestList)
+   UNITTEST_IMPL_TEST_FIXTURE(FixtureCtorAsserts, CorrectlyReportsAssertFailureInCtor, ctorAssertFixtureTestList)
    {}
 
    TEST(CorrectlyReportsFixturesWithCtorsThatAssert)


### PR DESCRIPTION
This PR accomplishes 2 things:

1. Gives users the ability to disable the "short" interface macros such as `CHECK` and `TEST`, which have a tendency to collide with other things, by defining `UNITTEST_DISABLE_SHORT_MACROS` in their project.
2. Normalizes project macros to be prefixed `UNITTEST_` if they are part of the public interface, and `UNITTEST_IMPL_` if they are not.

See #64 for motivation.

