### PR TITLE
Add UTPP_INCLUDE_TESTS_IN_BUILD CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,9 @@ project(UnitTest++)
 option(UTPP_USE_PLUS_SIGN
     "Set this to OFF if you wish to use '-cpp' instead of '++' in lib/include paths"
     ON)
-option(UTPP_SKIP_TESTS_AS_BUILD_STEP
-    "Set this to ON if you do not wish unit tests to run as part of cmake --build"
-    OFF)
+option(UTPP_RUN_TESTS_AS_BUILD_STEP
+    "Set this to OFF if you do not wish unit tests to run as part of cmake --build"
+    ON)
 
 if(MSVC14 OR MSVC12)
     # has the support we need
@@ -60,14 +60,14 @@ endif()
 
 target_link_libraries(TestUnitTest++ UnitTest++)
 
-if(${UTPP_SKIP_TESTS_AS_BUILD_STEP})
-    add_custom_command(TARGET TestUnitTest++
-        POST_BUILD COMMAND echo "TestUnitTest++ was not run as a build step because UTPP_SKIP_TESTS_AS_BUILD_STEP is ON")
-else()
+if(${UTPP_RUN_TESTS_AS_BUILD_STEP})
     # run unit tests as post build step
     add_custom_command(TARGET TestUnitTest++
-    	POST_BUILD COMMAND TestUnitTest++
-    	COMMENT "Running unit tests")
+        POST_BUILD COMMAND TestUnitTest++
+        COMMENT "Running unit tests")
+else()
+    add_custom_command(TARGET TestUnitTest++
+        POST_BUILD COMMAND echo "TestUnitTest++ was not run as a build step because UTPP_RUN_TESTS_AS_BUILD_STEP is OFF")
 endif()
 
 # add install targets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,12 @@
 cmake_minimum_required(VERSION 2.8.1)
 project(UnitTest++)
 
-option(UTPP_USE_PLUS_SIGN "Set this to OFF if you wish to use '-cpp' instead of '++' in lib/include paths" ON)
+option(UTPP_USE_PLUS_SIGN
+    "Set this to OFF if you wish to use '-cpp' instead of '++' in lib/include paths"
+    ON)
+option(UTPP_SKIP_TESTS_AS_BUILD_STEP
+    "Set this to ON if you do not wish unit tests to run as part of cmake --build"
+    OFF)
 
 if(MSVC14 OR MSVC12)
     # has the support we need
@@ -55,10 +60,15 @@ endif()
 
 target_link_libraries(TestUnitTest++ UnitTest++)
 
-# run unit tests as post build step
-add_custom_command(TARGET TestUnitTest++
-	POST_BUILD COMMAND TestUnitTest++
-	COMMENT "Running unit tests")
+if(${UTPP_SKIP_TESTS_AS_BUILD_STEP})
+    add_custom_command(TARGET TestUnitTest++
+        POST_BUILD COMMAND echo "TestUnitTest++ was not run as a build step because UTPP_SKIP_TESTS_AS_BUILD_STEP is ON")
+else()
+    # run unit tests as post build step
+    add_custom_command(TARGET TestUnitTest++
+    	POST_BUILD COMMAND TestUnitTest++
+    	COMMENT "Running unit tests")
+endif()
 
 # add install targets
 # need a custom install path?

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,8 @@ project(UnitTest++)
 option(UTPP_USE_PLUS_SIGN
     "Set this to OFF if you wish to use '-cpp' instead of '++' in lib/include paths"
     ON)
-option(UTPP_RUN_TESTS_AS_BUILD_STEP
-    "Set this to OFF if you do not wish unit tests to run as part of cmake --build"
+option(UTPP_INCLUDE_TESTS_IN_BUILD
+    "Set this to OFF if you do not wish to automatically build or run unit tests as part of the default cmake --build"
     ON)
 
 if(MSVC14 OR MSVC12)
@@ -60,14 +60,13 @@ endif()
 
 target_link_libraries(TestUnitTest++ UnitTest++)
 
-if(${UTPP_RUN_TESTS_AS_BUILD_STEP})
-    # run unit tests as post build step
-    add_custom_command(TARGET TestUnitTest++
-        POST_BUILD COMMAND TestUnitTest++
-        COMMENT "Running unit tests")
-else()
-    add_custom_command(TARGET TestUnitTest++
-        POST_BUILD COMMAND echo "TestUnitTest++ was not run as a build step because UTPP_RUN_TESTS_AS_BUILD_STEP is OFF")
+# run unit tests as post build step
+add_custom_command(TARGET TestUnitTest++
+    POST_BUILD COMMAND TestUnitTest++
+    COMMENT "Running unit tests")
+
+if(NOT ${UTPP_INCLUDE_TESTS_IN_BUILD})
+    set_target_properties(TestUnitTest++ PROPERTIES EXCLUDE_FROM_ALL 1)
 endif()
 
 # add install targets


### PR DESCRIPTION
This PR helps address #104 by giving the downstream project the ability to bypass tests at build time. The default behavior remains the same.