### PR TITLE
Take UnitTest::Check parameter by const reference

### DIFF
--- a/UnitTest++/Checks.h
+++ b/UnitTest++/Checks.h
@@ -9,7 +9,7 @@ namespace UnitTest {
 
 
    template< typename Value >
-   bool Check(Value const value)
+   bool Check(Value const& value)
    {
       return !!value; // doing double negative to avoid silly VS warnings
    }

--- a/tests/TestChecks.cpp
+++ b/tests/TestChecks.cpp
@@ -315,4 +315,32 @@ namespace {
       CHECK_EQUAL(1234, reporter.lastFailedLine);
    }
 
+   TEST(CheckProperlyDealsWithOperatorBoolOverrides)
+   {
+      class TruthyUnlessCopied
+      {
+      public:
+         TruthyUnlessCopied()
+         : truthy_(true)
+         {
+         }
+
+         TruthyUnlessCopied(const TruthyUnlessCopied& orig)
+         : truthy_(false)
+         {
+         }
+
+         operator bool() const
+         {
+            return truthy_;
+         }
+
+      private:
+         bool truthy_;
+      };
+
+      TruthyUnlessCopied objectThatShouldBeTruthy;
+      CHECK(objectThatShouldBeTruthy);
+   }
+
 }

--- a/tests/TestChecks.cpp
+++ b/tests/TestChecks.cpp
@@ -315,30 +315,30 @@ namespace {
       CHECK_EQUAL(1234, reporter.lastFailedLine);
    }
 
+   class TruthyUnlessCopied
+   {
+   public:
+      TruthyUnlessCopied()
+      : truthy_(true)
+      {
+      }
+
+      TruthyUnlessCopied(const TruthyUnlessCopied& orig)
+      : truthy_(false)
+      {
+      }
+
+      operator bool() const
+      {
+         return truthy_;
+      }
+
+   private:
+      bool truthy_;
+   };
+
    TEST(CheckProperlyDealsWithOperatorBoolOverrides)
    {
-      class TruthyUnlessCopied
-      {
-      public:
-         TruthyUnlessCopied()
-         : truthy_(true)
-         {
-         }
-
-         TruthyUnlessCopied(const TruthyUnlessCopied& orig)
-         : truthy_(false)
-         {
-         }
-
-         operator bool() const
-         {
-            return truthy_;
-         }
-
-      private:
-         bool truthy_;
-      };
-
       TruthyUnlessCopied objectThatShouldBeTruthy;
       CHECK(objectThatShouldBeTruthy);
    }

--- a/tests/TestChecks.cpp
+++ b/tests/TestChecks.cpp
@@ -323,7 +323,7 @@ namespace {
       {
       }
 
-      TruthyUnlessCopied(const TruthyUnlessCopied& orig)
+      TruthyUnlessCopied(const TruthyUnlessCopied&)
       : truthy_(false)
       {
       }


### PR DESCRIPTION
Fixes #119 and #7

It should be noted that this is going to result in version 2.0, as this is a potentially breaking interface change. As such I'm going to leave this PR open for a week or so for comment before merging.