### PR TITLE
Up MSVC warning levels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,9 @@ option(UTPP_USE_PLUS_SIGN
 option(UTPP_INCLUDE_TESTS_IN_BUILD
     "Set this to OFF if you do not wish to automatically build or run unit tests as part of the default cmake --build"
     ON)
+option(UTPP_AMPLIFY_WARNINGS
+    "Set this to OFF if you wish to use CMake default warning levels; should generally only use to work around support issues for your specific compiler"
+    ON)
 
 if(MSVC14 OR MSVC12)
     # has the support we need
@@ -20,6 +23,15 @@ else()
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
     else()
             message(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
+    endif()
+endif()
+
+# up warning level for project
+if (${UTPP_AMPLIFY_WARNINGS})
+    # instead of getting compiler specific, we're going to try making an assumption that an existing /W# means
+    # we are dealing with an MSVC or MSVC-like compiler (e.g. Intel on Windows)
+    if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
+        string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /WX")
     endif()
 endif()
 

--- a/UnitTest++/RequiredCheckTestReporter.h
+++ b/UnitTest++/RequiredCheckTestReporter.h
@@ -19,6 +19,9 @@ namespace UnitTest {
       bool Next();
 
    private:
+      RequiredCheckTestReporter(RequiredCheckTestReporter const&);
+      RequiredCheckTestReporter& operator =(RequiredCheckTestReporter const&);
+
       TestResults& m_results;
       TestReporter* m_originalTestReporter;
       ThrowingTestReporter m_throwingReporter;


### PR DESCRIPTION
Partial implentation of #10 for MSVC and MSVC-like compilers.

In case this introduces issues for anybody, the new CMake flag `UTPP_AMPLIFY_WARNINGS` can be set to OFF to turn off this behavior.

@dconnet wouldn't mind seeing your stamp of approval on this, since you wrote #107 .
