### PR TITLE
Up non-MSVC warning levels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ if (${UTPP_AMPLIFY_WARNINGS})
     if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
         string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /WX")
     else()
-        string(CONCAT CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}" " -Wall -Wextra -Werror -Wno-ignored-qualifiers")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -Wno-ignored-qualifiers")
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ if (${UTPP_AMPLIFY_WARNINGS})
     if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
         string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /WX")
     else()
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -Wno-ignored-qualifiers")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror")
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,8 @@ if (${UTPP_AMPLIFY_WARNINGS})
     # we are dealing with an MSVC or MSVC-like compiler (e.g. Intel on Windows)
     if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
         string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /WX")
+    else()
+        string(CONCAT CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}" " -Wall -Wextra -Werror -Wno-ignored-qualifiers")
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,9 @@ option(UTPP_USE_PLUS_SIGN
 option(UTPP_INCLUDE_TESTS_IN_BUILD
     "Set this to OFF if you do not wish to automatically build or run unit tests as part of the default cmake --build"
     ON)
+option(UTPP_AMPLIFY_WARNINGS
+    "Set this to OFF if you wish to use CMake default warning levels; should generally only use to work around support issues for your specific compiler"
+    ON)
 
 if(MSVC14 OR MSVC12)
     # has the support we need
@@ -20,6 +23,15 @@ else()
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
     else()
             message(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
+    endif()
+endif()
+
+# up warning level for project
+if (${UTPP_AMPLIFY_WARNINGS})
+    # instead of getting compiler specific, we're going to try making an assumption that an existing /W# means
+    # we are dealing with an MSVC or MSVC-like compiler (e.g. Intel on Windows)
+    if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
+        string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /WX")
     endif()
 endif()
 

--- a/UnitTest++/Posix/SignalTranslator.cpp
+++ b/UnitTest++/Posix/SignalTranslator.cpp
@@ -28,12 +28,12 @@ namespace UnitTest {
       sigaction( SIGFPE, &action, &m_old_SIGFPE_action  );
       sigaction( SIGTRAP, &action, &m_old_SIGTRAP_action );
       sigaction( SIGBUS, &action, &m_old_SIGBUS_action  );
-      sigaction( SIGILL, &action, &m_old_SIGBUS_action  );
+      sigaction( SIGILL, &action, &m_old_SIGILL_action  );
    }
 
    SignalTranslator::~SignalTranslator()
    {
-      sigaction( SIGILL, &m_old_SIGBUS_action, 0 );
+      sigaction( SIGILL, &m_old_SIGILL_action, 0 );
       sigaction( SIGBUS, &m_old_SIGBUS_action, 0 );
       sigaction( SIGTRAP, &m_old_SIGTRAP_action, 0 );
       sigaction( SIGFPE, &m_old_SIGFPE_action, 0 );

--- a/UnitTest++/Posix/SignalTranslator.h
+++ b/UnitTest++/Posix/SignalTranslator.h
@@ -22,8 +22,7 @@ namespace UnitTest {
       struct sigaction m_old_SIGTRAP_action;
       struct sigaction m_old_SIGSEGV_action;
       struct sigaction m_old_SIGBUS_action;
-      struct sigaction m_old_SIGABRT_action;
-      struct sigaction m_old_SIGALRM_action;
+      struct sigaction m_old_SIGILL_action;
    };
 
 #if !defined (__GNUC__)

--- a/UnitTest++/RequiredCheckTestReporter.h
+++ b/UnitTest++/RequiredCheckTestReporter.h
@@ -19,6 +19,9 @@ namespace UnitTest {
       bool Next();
 
    private:
+      RequiredCheckTestReporter(RequiredCheckTestReporter const&);
+      RequiredCheckTestReporter& operator =(RequiredCheckTestReporter const&);
+
       TestResults& m_results;
       TestReporter* m_originalTestReporter;
       ThrowingTestReporter m_throwingReporter;

--- a/tests/TestMemoryOutStream.cpp
+++ b/tests/TestMemoryOutStream.cpp
@@ -11,7 +11,7 @@ using namespace std;
 
 namespace {
 
-   const char* const maxSignedIntegralStr(size_t nBytes)
+   const char* maxSignedIntegralStr(size_t nBytes)
    {
       switch(nBytes)
       {
@@ -28,7 +28,7 @@ namespace {
       }
    }
 
-   const char* const minSignedIntegralStr(size_t nBytes)
+   const char* minSignedIntegralStr(size_t nBytes)
    {
       switch(nBytes)
       {
@@ -45,7 +45,7 @@ namespace {
       }
    }
 
-   const char* const maxUnsignedIntegralStr(size_t nBytes)
+   const char* maxUnsignedIntegralStr(size_t nBytes)
    {
       switch(nBytes)
       {


### PR DESCRIPTION
Depends on #126 .

Implementation of #10 intended for compilers that accept -W style warning arguments (GCC/Clang/similar).

In case this introduces issues for anybody, the new CMake flag UTPP_AMPLIFY_WARNINGS can be set to OFF to turn off this behavior.