### PR TITLE
Multiple TestList ability using dedicated chain node

### DIFF
--- a/UnitTest++/Test.cpp
+++ b/UnitTest++/Test.cpp
@@ -20,7 +20,6 @@ namespace UnitTest {
 
    Test::Test(char const* testName, char const* suiteName, char const* filename, int lineNumber)
       : m_details(testName, suiteName, filename, lineNumber)
-      , m_nextTest(0)
       , m_isMockTest(false)
    {}
 

--- a/UnitTest++/Test.h
+++ b/UnitTest++/Test.h
@@ -16,7 +16,6 @@ namespace UnitTest {
       void Run();
 
       TestDetails const m_details;
-      Test* m_nextTest;
 
       mutable bool m_isMockTest;
 

--- a/UnitTest++/TestList.cpp
+++ b/UnitTest++/TestList.cpp
@@ -5,11 +5,11 @@
 
 namespace UnitTest {
 
-	TestListNode::TestListNode(Test* test)
-		: m_test(test),
-		m_next(0)
-	{
-	}
+   TestListNode::TestListNode(Test* test)
+      : m_test(test),
+      m_next(0)
+   {
+   }
 
    TestList::TestList()
       : m_head(0)
@@ -23,16 +23,16 @@ namespace UnitTest {
       {
          assert(m_head == 0);
          node = new TestListNode(test);
-		 m_head = node;
-		 m_tail = node;
+         m_head = node;
+         m_tail = node;
       }
       else
       {
          node = new TestListNode(test);
-		 m_tail->m_next = node;
-		 m_tail = node;
+         m_tail->m_next = node;
+         m_tail = node;
       }
-	  return node;
+      return node;
    }
 
    TestListNode* TestList::GetHead() const

--- a/UnitTest++/TestList.cpp
+++ b/UnitTest++/TestList.cpp
@@ -5,27 +5,37 @@
 
 namespace UnitTest {
 
+	TestListNode::TestListNode(Test* test)
+		: m_test(test),
+		m_next(0)
+	{
+	}
+
    TestList::TestList()
       : m_head(0)
       , m_tail(0)
    {}
 
-   void TestList::Add(Test* test)
+   TestListNode* TestList::Add(Test* test)
    {
+      TestListNode* node = 0;
       if (m_tail == 0)
       {
          assert(m_head == 0);
-         m_head = test;
-         m_tail = test;
+         node = new TestListNode(test);
+		 m_head = node;
+		 m_tail = node;
       }
       else
       {
-         m_tail->m_nextTest = test;
-         m_tail = test;
+         node = new TestListNode(test);
+		 m_tail->m_next = node;
+		 m_tail = node;
       }
+	  return node;
    }
 
-   Test* TestList::GetHead() const
+   TestListNode* TestList::GetHead() const
    {
       return m_head;
    }

--- a/UnitTest++/TestList.h
+++ b/UnitTest++/TestList.h
@@ -10,18 +10,18 @@ namespace UnitTest {
    class UNITTEST_LINKAGE TestListNode
    {
    public:
-	   TestListNode(Test* test);
-	   Test* m_test;
-	   TestListNode* m_next;
+      TestListNode(Test* test);
+      Test* m_test;
+      TestListNode* m_next;
    };
 
    class UNITTEST_LINKAGE TestList
    {
    public:
       TestList();
-	  TestListNode* Add(Test* test);
 
-	  TestListNode* GetHead() const;
+      TestListNode* Add(Test* test);
+      TestListNode* GetHead() const;
 
    private:
       TestListNode* m_head;

--- a/UnitTest++/TestList.h
+++ b/UnitTest++/TestList.h
@@ -7,17 +7,25 @@ namespace UnitTest {
 
    class Test;
 
+   class UNITTEST_LINKAGE TestListNode
+   {
+   public:
+	   TestListNode(Test* test);
+	   Test* m_test;
+	   TestListNode* m_next;
+   };
+
    class UNITTEST_LINKAGE TestList
    {
    public:
       TestList();
-      void Add (Test* test);
+	  TestListNode* Add(Test* test);
 
-      Test* GetHead() const;
+	  TestListNode* GetHead() const;
 
    private:
-      Test* m_head;
-      Test* m_tail;
+      TestListNode* m_head;
+      TestListNode* m_tail;
    };
 
 

--- a/UnitTest++/TestRunner.h
+++ b/UnitTest++/TestRunner.h
@@ -31,14 +31,14 @@ namespace UnitTest {
       int RunTestsIf(TestList const& list, char const* suiteName,
                      const Predicate& predicate, int maxTestTimeInMs) const
       {
-         Test* curTest = list.GetHead();
+         TestListNode* curTest = list.GetHead();
 
          while (curTest != 0)
          {
-            if (IsTestInSuite(curTest, suiteName) && predicate(curTest))
-               RunTest(m_result, curTest, maxTestTimeInMs);
+            if (IsTestInSuite(curTest->m_test, suiteName) && predicate(curTest->m_test))
+               RunTest(m_result, curTest->m_test, maxTestTimeInMs);
 
-            curTest = curTest->m_nextTest;
+            curTest = curTest->m_next;
          }
 
          return Finish();

--- a/tests/TestTestList.cpp
+++ b/tests/TestTestList.cpp
@@ -32,7 +32,7 @@ namespace {
       TestListNode* test2Node = list.Add(&test2);
 
       CHECK(list.GetHead()->m_test == &test1);
-	  CHECK(test1Node->m_next->m_test == &test2);
+      CHECK(test1Node->m_next->m_test == &test2);
       CHECK(test2Node->m_next == 0);
    }
 

--- a/tests/TestTestList.cpp
+++ b/tests/TestTestList.cpp
@@ -18,8 +18,8 @@ namespace {
       TestList list;
       list.Add(&test);
 
-      CHECK(list.GetHead() == &test);
-      CHECK(test.m_nextTest == 0);
+      CHECK(list.GetHead()->m_test == &test);
+      CHECK(list.GetHead()->m_next == 0);
    }
 
    TEST(AddingSecondTestAddsItToEndOfList)
@@ -28,12 +28,12 @@ namespace {
       Test test2("test2");
 
       TestList list;
-      list.Add(&test1);
-      list.Add(&test2);
+      TestListNode* test1Node = list.Add(&test1);
+      TestListNode* test2Node = list.Add(&test2);
 
-      CHECK(list.GetHead() == &test1);
-      CHECK(test1.m_nextTest == &test2);
-      CHECK(test2.m_nextTest == 0);
+      CHECK(list.GetHead()->m_test == &test1);
+	  CHECK(test1Node->m_next->m_test == &test2);
+      CHECK(test2Node->m_next == 0);
    }
 
    TEST(ListAdderAddsTestToList)
@@ -43,8 +43,8 @@ namespace {
       Test test("");
       ListAdder adder(list, &test);
 
-      CHECK(list.GetHead() == &test);
-      CHECK(test.m_nextTest == 0);
+      CHECK(list.GetHead()->m_test == &test);
+      CHECK(list.GetHead()->m_next == 0);
    }
 
 }

--- a/tests/TestTestMacros.cpp
+++ b/tests/TestTestMacros.cpp
@@ -52,7 +52,7 @@ namespace {
    TEST (TestsAreAddedToTheListThroughMacro)
    {
       CHECK(list1.GetHead() != 0);
-      CHECK(list1.GetHead()->m_nextTest == 0);
+      CHECK(list1.GetHead()->m_next == 0);
    }
 
 #ifndef UNITTEST_NO_EXCEPTIONS
@@ -78,7 +78,7 @@ namespace {
       TestResults result(&reporter);
       {
          ScopedCurrentTest scopedResults(result);
-         list2.GetHead()->Run();
+         list2.GetHead()->m_test->Run();
       }
 
       CHECK(strstr(reporter.lastFailedMessage, "xception"));
@@ -119,8 +119,8 @@ namespace {
    TEST(TestAddedWithTEST_EXMacroGetsDefaultSuite)
    {
       CHECK(macroTestList1.GetHead() != NULL);
-      CHECK_EQUAL ("MacroTestHelper1", macroTestList1.GetHead()->m_details.testName);
-      CHECK_EQUAL ("DefaultSuite", macroTestList1.GetHead()->m_details.suiteName);
+      CHECK_EQUAL ("MacroTestHelper1", macroTestList1.GetHead()->m_test->m_details.testName);
+      CHECK_EQUAL ("DefaultSuite", macroTestList1.GetHead()->m_test->m_details.suiteName);
    }
 
    TestList macroTestList2;
@@ -130,8 +130,8 @@ namespace {
    TEST(TestAddedWithTEST_FIXTURE_EXMacroGetsDefaultSuite)
    {
       CHECK(macroTestList2.GetHead() != NULL);
-      CHECK_EQUAL ("MacroTestHelper2", macroTestList2.GetHead()->m_details.testName);
-      CHECK_EQUAL ("DefaultSuite", macroTestList2.GetHead()->m_details.suiteName);
+      CHECK_EQUAL ("MacroTestHelper2", macroTestList2.GetHead()->m_test->m_details.testName);
+      CHECK_EQUAL ("DefaultSuite", macroTestList2.GetHead()->m_test->m_details.suiteName);
    }
 
 #ifndef UNITTEST_NO_EXCEPTIONS
@@ -154,7 +154,7 @@ namespace {
       TestResults result(&reporter);
       {
          ScopedCurrentTest scopedResult(result);
-         throwingFixtureTestList1.GetHead()->Run();
+         throwingFixtureTestList1.GetHead()->m_test->Run();
       }
 
       int const failureCount = result.GetFailedTestCount();
@@ -181,7 +181,7 @@ namespace {
       TestResults result(&reporter);
       {
          ScopedCurrentTest scopedResult(result);
-         throwingFixtureTestList2.GetHead()->Run();
+         throwingFixtureTestList2.GetHead()->m_test->Run();
       }
 
       int const failureCount = result.GetFailedTestCount();
@@ -209,7 +209,7 @@ namespace {
       TestResults result(&reporter);
       {
          ScopedCurrentTest scopedResults(result);
-         ctorAssertFixtureTestList.GetHead()->Run();
+         ctorAssertFixtureTestList.GetHead()->m_test->Run();
       }
 
       const int failureCount = result.GetFailedTestCount();


### PR DESCRIPTION
Moved notion of "next test" from `Test` class to dedicated class `TestListNode` for being able to manage several `TestList` undependently instead of a single one.

This will be required for the next feature I will suggest : a test runner which accepts arguments from cmd like "--test", "--suite" etc.