### PR TITLE
Do not swallow non-expected exceptions in CHECK_THROW

### DIFF
--- a/UnitTest++/CheckMacros.h
+++ b/UnitTest++/CheckMacros.h
@@ -184,7 +184,6 @@
    bool caught_ = false;                                                                                                                                                                    \
    try { expression; }                                                                                                                                                                      \
    catch (ExpectedExceptionType const&) { caught_ = true; }                                                                                                                                 \
-   catch (...) {}                                                                                                                                                                           \
    if (!caught_)                                                                                                                                                                            \
       UnitTest::CurrentTest::Results()->OnTestFailure(UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), "Expected exception: \"" #ExpectedExceptionType "\" not thrown"); \
    UNITTEST_MULTILINE_MACRO_END


### PR DESCRIPTION
The problem is that you have the same error message when: 

- _No exception have been thrown_, which is what we want to check
- _An other exception than expected has been thrown_, which means there is an unexpected failure

When an other exception occurs it means an other problem has been detected, and it should not be dissimulated behind a wrong message. Remove the statement will restablish the correct message `error: Failure in MyTest: Unhandled exception: test crashed`

Thanks