### PR TITLE
Added autogen.sh file to ease autotools installation

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+test -e ./.autotools_aux || mkdir .autotools_aux
+
+libtoolize -cq
+aclocal -I m4 --install           # Generate aclocal
+autoconf                          # Generate configure script 
+autoheader                        # Generate config.h
+automake --add-missing --copy     # Generate Makefile.in and other scripts 


### PR DESCRIPTION
I just added a autogen.sh file to avoid issuing `aclocal; autoreconf -i; autoconf`.

Its a simple script which calls all the autotools commands in order. I have been using it in my
unittest++ fork for a little while.