### PR TITLE
Add support for Cygwin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,10 @@ endif(WIN32)
 
 file(GLOB platformHeaders_ RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} UnitTest++/${platformDir_}/*.h)
 file(GLOB platformSources_ RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} UnitTest++/${platformDir_}/*.cpp)
+if(CYGWIN)
+    list(REMOVE_ITEM platformHeaders_ UnitTest++/${platformDir_}/SignalTranslator.h)
+    list(REMOVE_ITEM platformSources_ UnitTest++/${platformDir_}/SignalTranslator.cpp)
+endif()
 source_group(${platformDir_} FILES ${platformHeaders_} ${platformSources_})
 
 # create the lib

--- a/UnitTest++/Config.h
+++ b/UnitTest++/Config.h
@@ -20,10 +20,16 @@
    #define UNITTEST_WIN32
 #endif
 
+#ifndef __CYGWIN__
 #if defined(unix) || defined(__unix__) || defined(__unix) || defined(linux) || \
    defined(__APPLE__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__FreeBSD__) \
    || defined (__HAIKU__)
    #define UNITTEST_POSIX
+#endif
+#endif
+
+#if defined(__CYGWIN__)
+   #define UNITTEST_CYGWIN
 #endif
 
 #if defined(__MINGW32__)

--- a/UnitTest++/Posix/TimeHelpers.cpp
+++ b/UnitTest++/Posix/TimeHelpers.cpp
@@ -1,4 +1,6 @@
 #include "TimeHelpers.h"
+#include <chrono>
+#include <thread>
 #include <unistd.h>
 
 namespace UnitTest {
@@ -27,7 +29,7 @@ namespace UnitTest {
 
    void TimeHelpers::SleepMs(int ms)
    {
-      usleep(static_cast<useconds_t>(ms * 1000));
+      std::this_thread::sleep_for(std::chrono::microseconds(ms * 1000));
    }
 
 }

--- a/UnitTest++/TimeHelpers.h
+++ b/UnitTest++/TimeHelpers.h
@@ -1,6 +1,6 @@
 #include "Config.h"
 
-#if defined UNITTEST_POSIX
+#if defined(UNITTEST_POSIX) || defined(UNITTEST_CYGWIN)
    #include "Posix/TimeHelpers.h"
 #else
    #include "Win32/TimeHelpers.h"


### PR DESCRIPTION
Add UNITTEST_CYGWIN directive and use it to:
include Posix/TimeHelpers.h for Cygwin,
exclude the signal handling in SignalTranslator.h/.cpp as Cygwin does not have
the necessary Posix signal handling support, i.e. sigjmp_buf or siglongjmp.

Reimplement SleepMs in TimeHelpers.cpp using C++11 rather than usleep as that
is not present on Cygwin.

Update CMakeLists.txt to exclude SignalTranslator.h/.cpp from the build.