### PR TITLE
add support to build unittest cpp on AIX (IBM)

### DIFF
--- a/UnitTest++/Config.h
+++ b/UnitTest++/Config.h
@@ -22,7 +22,7 @@
 
 #if defined(unix) || defined(__unix__) || defined(__unix) || defined(linux) || \
    defined(__APPLE__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__FreeBSD__) \
-   || defined (__HAIKU__)
+   || defined (__HAIKU__) || defined(_AIX)
    #define UNITTEST_POSIX
 #endif
 


### PR DESCRIPTION
Adding this simple flag allows to build unittest cpp on the IBM unix AIX via the IBM Opensource Toolbox.