### PR TITLE
tests/TestTestRunner.cpp: avoid referencing yet unitialized member

### DIFF
--- a/tests/TestTestRunner.cpp
+++ b/tests/TestTestRunner.cpp
@@ -60,8 +60,8 @@ namespace
          return result;
       }
 
-      TestRunner runner;
       RecordingReporter reporter;
+      TestRunner runner;
    };
 
    struct TestRunnerFixture : public FixtureBase


### PR DESCRIPTION
On recent gcc-12 snapshot build fails as:

    [ 52%] Building CXX object CMakeFiles/TestUnitTest++.dir/tests/TestTestRunner.cpp.o
    unittest-cpp/tests/TestTestRunner.cpp:
      In constructor '{anonymous}::FixtureBase::FixtureBase()':
    unittest-cpp/tests/TestTestRunner.cpp:48:19:
      error: member '{anonymous}::FixtureBase::reporter' is used uninitialized [-Werror=uninitialized]
       48 |          : runner(reporter)
          |                   ^~~~~~~~
    cc1plus: all warnings being treated as errors

On https://gcc.gnu.org/PR103375 Andrew suggested to match order of class
members to avoid picking a member reference to yet unconstructed object.