### PR TITLE
Update TestTestRunner.cpp to remove warning 

### DIFF
--- a/tests/TestTestRunner.cpp
+++ b/tests/TestTestRunner.cpp
@@ -60,8 +60,8 @@ namespace
          return result;
       }
 
-      TestRunner runner;
       RecordingReporter reporter;
+      TestRunner runner;
    };
 
    struct TestRunnerFixture : public FixtureBase


### PR DESCRIPTION
"error: member ‘{anonymous}::FixtureBase::reporter’ is used uninitialized"

I have switched so that arg to constructor is declared before the constructed object. 